### PR TITLE
[Patch v1.2.0]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>RoseDB</artifactId>
     <groupId>pw.mihou</groupId>
-    <version>1.2.0-SNAPSHOT</version>
+    <version>1.2.0</version>
     <name>RoseDB</name>
     <description>A simple NoSQL Database that is written completely in Java.</description>
     <url>https://github.com/ShindouMihou/RoseDB/</url>
@@ -59,6 +59,8 @@
                     <descriptorRefs>
                         <descriptorRef>jar-with-dependencies</descriptorRef>
                     </descriptorRefs>
+                    <finalName>RoseDB</finalName>
+                    <appendAssemblyId>false</appendAssemblyId>
                     <archive>
                         <manifest>
                             <mainClass>pw.mihou.rosedb.RoseDB</mainClass>

--- a/pom.xml
+++ b/pom.xml
@@ -3,9 +3,8 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-
-    <groupId>pw.mihou</groupId>
     <artifactId>RoseDB</artifactId>
+    <groupId>pw.mihou</groupId>
     <version>1.2.0-SNAPSHOT</version>
     <name>RoseDB</name>
     <description>A simple NoSQL Database that is written completely in Java.</description>
@@ -109,15 +108,29 @@
             <version>2.8.0</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-assembly-plugin</artifactId>
-            <version>3.3.0</version>
-            <type>maven-plugin</type>
-        </dependency>
-        <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
             <version>1.15</version>
+        </dependency>
+        <dependency>
+            <groupId>com.github.vladimir-bukhtoyarov</groupId>
+            <artifactId>bucket4j-core</artifactId>
+            <version>6.2.0</version>
+        </dependency>
+        <dependency>
+            <groupId>io.github.resilience4j</groupId>
+            <artifactId>resilience4j-retry</artifactId>
+            <version>1.7.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.github.sbtourist</groupId>
+            <artifactId>journalio</artifactId>
+            <version>1.4.2</version>
+        </dependency>
+        <dependency>
+            <groupId>io.github.resilience4j</groupId>
+            <artifactId>resilience4j-timelimiter</artifactId>
+            <version>1.7.0</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,41 @@
 
     <groupId>pw.mihou</groupId>
     <artifactId>RoseDB</artifactId>
-    <version>1.1.0</version>
+    <version>1.2.0-SNAPSHOT</version>
+    <name>RoseDB</name>
+    <description>A simple NoSQL Database that is written completely in Java.</description>
+    <url>https://github.com/ShindouMihou/RoseDB/</url>
+    <licenses>
+        <license>
+            <name>Apache 2.0 License</name>
+            <url>https://github.com/ShindouMihou/RoseDB/blob/master/LICENSE</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+    <developers>
+        <developer>
+            <id>mihoushindou</id>
+            <name>Shindou Mihou</name>
+            <email>kokocrunchsh@gmail.com</email>
+            <organization>Mana Network</organization>
+            <organizationUrl>https://manabot.fun</organizationUrl>
+            <roles>
+                <role>developer</role>
+            </roles>
+            <timezone>+8</timezone>
+            <properties>
+                <picUrl>https://avatars.githubusercontent.com/u/69381903</picUrl>
+            </properties>
+        </developer>
+    </developers>
+
+    <scm>
+        <connection>scm:git:git://github.com/ShindouMihou/RoseDB.git</connection>
+        <developerConnection>scm:git:git://github.com/ShindouMihou/RoseDB.git</developerConnection>
+        <url>https://github.com/ShindouMihou/RoseDB.git</url>
+        <tag>HEAD</tag>
+    </scm>
+
     <build>
         <plugins>
             <plugin>
@@ -50,9 +84,19 @@
 
     <dependencies>
         <dependency>
-            <groupId>io.javalin</groupId>
-            <artifactId>javalin</artifactId>
-            <version>3.13.7</version>
+            <groupId>org.java-websocket</groupId>
+            <artifactId>Java-WebSocket</artifactId>
+            <version>1.5.1</version>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>3.0.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains</groupId>
+            <artifactId>annotations</artifactId>
+            <version>21.0.1</version>
         </dependency>
         <dependency>
             <groupId>org.json</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,11 @@
             <version>1.2.3</version>
         </dependency>
         <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.8.7</version>
+        </dependency>
+        <dependency>
             <groupId>com.github.ben-manes.caffeine</groupId>
             <artifactId>caffeine</artifactId>
             <version>3.0.2</version>

--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,11 @@
             <type>maven-plugin</type>
         </dependency>
         <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <version>1.15</version>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>1.7.30</version>

--- a/src/main/java/pw/mihou/rosedb/RoseDB.java
+++ b/src/main/java/pw/mihou/rosedb/RoseDB.java
@@ -92,14 +92,6 @@ public class RoseDB {
         disableAllExternalLogging();
         Terminal.setLoggingLevel(Level.ERROR);
 
-        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-            try {
-                journal.close();
-            } catch (IOException exception) {
-                Terminal.log(Levels.ERROR, "Attempt to close journal was met with {}", exception.getMessage());
-            }
-        }));
-
         if (!new File("config.json").exists()) {
             RoseWriter.write("config.json", defaultConfig().toString(4));
         }

--- a/src/main/java/pw/mihou/rosedb/connections/RoseServer.java
+++ b/src/main/java/pw/mihou/rosedb/connections/RoseServer.java
@@ -27,6 +27,7 @@ import java.util.Optional;
 import java.util.Scanner;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 public class RoseServer {
 
@@ -67,6 +68,8 @@ public class RoseServer {
 
     public static synchronized void removeDatabase(String db) throws IOException {
         database.invalidate(db.toLowerCase());
+        FileHandler.queue.removeAll(FileHandler.queue.stream().filter(r -> r.database.equals(db))
+                .collect(Collectors.toUnmodifiableList()));
         FileUtils.deleteDirectory(new File(String.format(RoseDB.directory + "/%s/", db)));
     }
 

--- a/src/main/java/pw/mihou/rosedb/connections/RoseServer.java
+++ b/src/main/java/pw/mihou/rosedb/connections/RoseServer.java
@@ -27,6 +27,7 @@ public class RoseServer {
 
     public static final Map<String, WebSocket> context = new ConcurrentHashMap<>();
     private static final Scanner scanner = new Scanner(System.in).useDelimiter("\n");
+    public static boolean isOpen = true;
 
     /**
      * Replies to the client that doesn't have
@@ -148,6 +149,7 @@ public class RoseServer {
                     })))));
         }
 
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> isOpen = false));
         Runtime.getRuntime().addShutdownHook(new Thread(RoseWriter::write));
         Runtime.getRuntime().addShutdownHook(new Thread(Scheduler::shutdown));
         Runtime.getRuntime().addShutdownHook(new Thread(() -> {

--- a/src/main/java/pw/mihou/rosedb/connections/RoseServer.java
+++ b/src/main/java/pw/mihou/rosedb/connections/RoseServer.java
@@ -1,16 +1,7 @@
 package pw.mihou.rosedb.connections;
 
 import ch.qos.logback.classic.Level;
-import com.github.benmanes.caffeine.cache.Caffeine;
-import com.github.benmanes.caffeine.cache.LoadingCache;
-import io.javalin.Javalin;
-import io.javalin.core.compression.CompressionStrategy;
-import io.javalin.websocket.WsContext;
-import org.apache.commons.codec.digest.DigestUtils;
-import org.apache.commons.codec.digest.HmacAlgorithms;
-import org.apache.commons.codec.digest.HmacUtils;
-import org.apache.commons.io.FileUtils;
-import org.eclipse.jetty.websocket.api.MessageTooLargeException;
+import org.java_websocket.WebSocket;
 import org.json.JSONException;
 import org.json.JSONObject;
 import pw.mihou.rosedb.RoseDB;
@@ -19,141 +10,131 @@ import pw.mihou.rosedb.io.FileHandler;
 import pw.mihou.rosedb.io.RoseQuery;
 import pw.mihou.rosedb.io.Scheduler;
 import pw.mihou.rosedb.io.entities.QueryRequest;
-import pw.mihou.rosedb.listeners.*;
+import pw.mihou.rosedb.io.writers.RoseWriter;
 import pw.mihou.rosedb.manager.RoseDatabase;
 import pw.mihou.rosedb.manager.RoseListenerManager;
+import pw.mihou.rosedb.server.ServerApplication;
 import pw.mihou.rosedb.utility.Terminal;
 
 import java.io.File;
 import java.io.IOException;
-import java.security.MessageDigest;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Scanner;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 
 public class RoseServer {
 
-    private static final Map<String, WsContext> context = new ConcurrentHashMap<>();
-    private static final Map<String, String> contextAttributes = new ConcurrentHashMap<>();
-    private static final LoadingCache<String, RoseDatabase> database = Caffeine.newBuilder()
-            .build(key -> FileHandler.readDatabase(key.toLowerCase()).join());
+    public static final Map<String, WebSocket> context = new ConcurrentHashMap<>();
     private static final Scanner scanner = new Scanner(System.in).useDelimiter("\n");
 
-    public static void reply(WsContext context, String response, int kode) {
-        if (context != null) {
-            context.send(new JSONObject().put("response", response).put("kode", kode).toString());
-        } else {
-            Terminal.log(Levels.INFO, new JSONObject().put("response", response).put("kode", kode).toString());
-        }
+    /**
+     * Replies to the client that doesn't have
+     * a unique field.
+     *
+     * @param context The websocket context.
+     * @param response The response to send.
+     * @param kode The kode response.
+     */
+    public static void reply(WebSocket context, String response, int kode) {
+        reply(context, new JSONObject().put("response", response).put("kode", kode));
     }
 
-    public static void reply(WsContext context, JSONObject response, String unique, int kode) {
-        if (context != null) {
-            context.send(response.put("kode", kode).put("replyTo", unique).toString());
-        } else {
-            Terminal.log(Levels.INFO, response.put("kode", kode).put("replyTo", unique).toString());
-        }
+    /**
+     * Replies to the client in full detail,
+     * this includes a unique field.
+     *
+     * @param context The websocket context.
+     * @param response The response to send.
+     * @param unique The unique callback field received.
+     * @param kode The kode response.
+     */
+    public static void reply(WebSocket context, JSONObject response, String unique, int kode) {
+        reply(context, response.put("kode", kode).put("replyTo", unique));
     }
 
-    public static void reply(WsContext context, String response, String unique, int kode) {
-        if (context != null) {
-            context.send(new JSONObject().put("response", response).put("kode", kode)
-                    .put("replyTo", unique).toString());
-        } else {
-            Terminal.log(Levels.INFO, new JSONObject().put("response", response).put("kode", kode)
-                    .put("replyTo", unique).toString());
-        }
+    /**
+     * Replies to the client in full detail but
+     * with a String argument.
+     *
+     * @param context The websocket context.
+     * @param response The response to send.
+     * @param unique The unique callback field received.
+     * @param kode The kode response.
+     */
+    public static void reply(WebSocket context, String response, String unique, int kode) {
+        reply(context, new JSONObject().put("response", response).put("kode", kode)
+                .put("replyTo", unique));
     }
 
-    public static RoseDatabase getDatabase(String db) {
-        return database.get(db.toLowerCase());
+    /**
+     * Replies to the client.
+     *
+     * @param context The websocket context.
+     * @param response The response including any other add-ons.
+     */
+    public static void reply(WebSocket context, JSONObject response){
+        if(context == null)
+            Terminal.log(Levels.INFO, response.toString());
+        else
+            context.send(response.toString());
     }
 
-    public static synchronized void removeDatabase(String db) throws IOException {
-        database.invalidate(db.toLowerCase());
-        FileHandler.queue.removeAll(FileHandler.queue.stream().filter(r -> r.database.equals(db))
-                .collect(Collectors.toUnmodifiableList()));
-        FileUtils.deleteDirectory(new File(String.format(RoseDB.directory + "/%s/", db)));
-    }
-
-    private static void register() {
-        RoseListenerManager.register(new RequestListener());
-        RoseListenerManager.register(new AddListener());
-        RoseListenerManager.register(new DeleteListener());
-        RoseListenerManager.register(new UpdateListener());
-        RoseListenerManager.register(new DropListener());
-        RoseListenerManager.register(new AggregateListener());
-        RoseListenerManager.register(new RevertListener());
-    }
-
+    /**
+     * Starts the heartbeat sending towards
+     * all the client to keep them from disconnecting
+     * because of timeout.
+     */
     private static void startHeartbeat() {
         Scheduler.schedule(() -> context.values()
                 .stream()
-                .filter(wsContext -> wsContext.session.isOpen())
-                .forEach(wsContext -> wsContext.send(new JSONObject()
-                        .put("session", wsContext.getSessionId())
-                        .put("kode", 0).toString())), RoseDB.heartbeat, RoseDB.heartbeat, TimeUnit.SECONDS);
+                .filter(WebSocket::isOpen)
+                .forEach(wsContext -> {
+                    wsContext.send(new JSONObject()
+                            .put("session", (String) wsContext.getAttachment())
+                            .toString());
+                    wsContext.sendPing();
+                }), RoseDB.heartbeat, RoseDB.heartbeat, TimeUnit.SECONDS);
         Terminal.log(Levels.DEBUG, "Heartbeat listener is now active.");
     }
 
+    /**
+     * Starts the writing service of the application.
+     * This will write all requests that have gathered around
+     * within five seconds.
+     */
     private static void startWriter() {
-        Scheduler.schedule(FileHandler::write, 5, 5, TimeUnit.SECONDS);
+        Scheduler.schedule(RoseWriter::write, 5, 5, TimeUnit.SECONDS);
     }
 
+    /**
+     * Starts and runs the websocket server
+     * of the application. This should only be called once
+     * and it should be done at main().
+     *
+     * @param port The port which the server will be running at.
+     */
     public static void run(int port) {
-        register();
-        Terminal.log(Levels.DEBUG, "All listeners are registered.");
-
         if (Terminal.root == Level.DEBUG) {
             Terminal.log(Levels.WARNING, "For maximum performance, we recommend turning off DEBUG mode unless needed (especially when requests can reach large sizes).");
         }
 
         if (RoseDB.preload) {
             Terminal.log(Levels.INFO, "Pre-caching all data ahead of time, you may disable this behavior in config.json if you don't mind performance decrease.");
-            FileHandler.preloadAll().thenAccept(unused -> Terminal.log(Levels.INFO, "All data are now pre-loaded into cache!"));
+            FileHandler.preloadAll();
+            Terminal.log(Levels.INFO, "All data are now pre-loaded into cache!");
         } else {
             Terminal.log(Levels.WARNING, "Please note that disabling preloading will cause performance to be lower.");
         }
 
-        Javalin app = Javalin.create(config -> {
-            config.defaultContentType = "application/json";
-            config.showJavalinBanner = false;
-            config.compressionStrategy(CompressionStrategy.GZIP);
-            config.wsFactoryConfig(ws -> {
-                ws.getPolicy().setMaxTextMessageBufferSize(RoseDB.buffer * 1024 * 1024);
-                ws.getPolicy().setMaxTextMessageSize(RoseDB.size * 1024 * 1024);
-            });
-
-            config.wsLogger(wsHandler -> {
-                wsHandler.onConnect(wsConnectContext -> Terminal.log(Levels.DEBUG, "Received connection from {}", wsConnectContext.session.getRemoteAddress().toString()));
-                wsHandler.onClose(wsCloseContext -> Terminal.log(Levels.DEBUG, "Received closed connection from {} for {}", wsCloseContext.session.getRemoteAddress().toString(), wsCloseContext.reason()));
-                wsHandler.onMessage(ctx -> Terminal.log(Levels.DEBUG, "Received request: {} from {}", ctx.message(), ctx.session.getRemoteAddress().toString()));
-            });
-        });
-
-        app.events(event -> {
-            event.serverStarting(() -> Terminal.log(Levels.DEBUG, "The server is now starting at port: {}", port));
-            event.serverStarted(() -> Terminal.log(Levels.DEBUG, "The server has started on port: {}", port));
-            event.serverStartFailed(() -> Terminal.log(Levels.ERROR, "The server failed to start, possibly another instance at the same port is running."));
-            event.serverStopping(() -> Terminal.log(Levels.INFO, "The server is now shutting off."));
-            event.serverStopped(() -> Terminal.log(Levels.INFO, "The server has successfully closed."));
-        }).start(port);
-
-        Runtime.getRuntime().addShutdownHook(new Thread(() -> context.values().stream().filter(wsContext -> wsContext.session.isOpen())
-                .forEachOrdered(wsContext -> wsContext.session.close(4002, "RoseDB is closing."))));
+        ServerApplication app = new ServerApplication(port);
+        app.start();
 
         if (RoseDB.versioning) {
-            Runtime.getRuntime().addShutdownHook(new Thread(() -> database.asMap().values().forEach(roseDatabase -> roseDatabase.getCollections()
+            Runtime.getRuntime().addShutdownHook(new Thread(() -> RoseDatabase.databases.asMap().values().forEach(roseDatabase -> roseDatabase.getCollections()
                     .forEach(collections -> collections.getVersions().forEach((s, s2) -> {
-                        String location = new StringBuilder(".rose_versions")
-                                .append(File.separator)
-                                .append(roseDatabase.getDatabase())
-                                .append(File.separator)
-                                .append(collections.collection)
-                                .append(File.separator).toString();
+                        String location = ".rose_versions" + File.separator + roseDatabase.getDatabase() + File.separator +
+                                collections.collection + File.separator;
 
                         if (!new File(location).exists()) {
                             boolean mkdirs = new File(location).mkdirs();
@@ -163,49 +144,21 @@ public class RoseServer {
                             }
                         }
 
-                        FileHandler.writeGzip(location + s + ".rose", s2);
+                        RoseWriter.writeGZIP(location + s + ".rose", s2);
                     })))));
         }
 
-        Runtime.getRuntime().addShutdownHook(new Thread(app::stop));
-        Runtime.getRuntime().addShutdownHook(new Thread(FileHandler::write));
+        Runtime.getRuntime().addShutdownHook(new Thread(RoseWriter::write));
         Runtime.getRuntime().addShutdownHook(new Thread(Scheduler::shutdown));
-
-        Terminal.log(Levels.DEBUG, "All events and handlers are now ready.");
-
-        app.wsBefore(wsHandler -> wsHandler.onConnect(ctx -> {
-            if(ctx.header("Authorization") == null){
-                ctx.session.close(4001, "Missing or invalid Authorization header.");
-                return;
-            }
-
-            if (MessageDigest.isEqual(new HmacUtils(HmacAlgorithms.HMAC_SHA_256, RoseDB.secret)
-                            .hmacHex(ctx.header("Authorization")).getBytes(), RoseDB.authorization)){
-                context.put(ctx.getSessionId(), ctx);
-            } else {
-                ctx.session.close(4001, "Missing or invalid Authorization header.");
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            try {
+                app.stop();
+            } catch (IOException | InterruptedException exception) {
+                Terminal.log(Levels.ERROR, "An exception occurred while trying to close server: {}", exception.getMessage());
             }
         }));
 
-        app.ws("/", ws -> {
-
-            ws.onClose(ctx -> context.remove(ctx.getSessionId()));
-            ws.onMessage(ctx -> {
-                try {
-                    QueryRequest req = RoseQuery.parse(ctx.message());
-                    if(!req.isValid())
-                        RoseListenerManager.execute(new JSONObject(ctx.message()), ctx);
-                    else
-                        RoseListenerManager.execute(req, ctx);
-                } catch (JSONException e) {
-                    reply(ctx, "The request was considered as invalid: " + e.getMessage(), -1);
-                    Terminal.log(Levels.DEBUG, "Received invalid JSON request: {} from {}", ctx.message(), ctx.session.getRemoteAddress().toString());
-                } catch (MessageTooLargeException e) {
-                    reply(ctx, "The request was canceled by force: " + e.getMessage(), -1);
-                    Terminal.log(Levels.ERROR, "Received message that was too large from {}", ctx.session.getRemoteAddress().toString());
-                }
-            });
-        });
+        Terminal.log(Levels.DEBUG, "All events and handlers are now ready.");
 
         Terminal.log(Levels.INFO, "RoseDB is now running on port: {}", port);
         startHeartbeat();
@@ -216,16 +169,13 @@ public class RoseServer {
             QueryRequest query = RoseQuery.parse(request);
             try {
                 if(query.isValid()){
-                    RoseListenerManager.execute(query.asJSONObject(), null);
+                    RoseListenerManager.execute(query, null);
                 } else {
                     RoseListenerManager.execute(new JSONObject(request), null);
                 }
             } catch (JSONException e) {
                 reply(null, "The request was considered as invalid: " + request, -1);
                 Terminal.log(Levels.DEBUG, "Received invalid JSON request: {} from terminal", request);
-            } catch (MessageTooLargeException e) {
-                reply(null, "The request was canceled by force: " + e.getMessage(), -1);
-                Terminal.log(Levels.ERROR, "Received message that was too large from terminal.");
             }
         }
     }

--- a/src/main/java/pw/mihou/rosedb/enums/Levels.java
+++ b/src/main/java/pw/mihou/rosedb/enums/Levels.java
@@ -2,11 +2,41 @@ package pw.mihou.rosedb.enums;
 
 public enum Levels {
 
-    INFO("INFO", -1), ERROR("ERROR", 1), DEBUG("DEBUG", 2), WARNING("WARNING", 0);
+    /**
+     * Record only logs below or equal to INFO.
+     */
+    INFO("INFO", -1),
 
+    /**
+     * Record only logs below or equal to ERROR.
+     */
+    ERROR("ERROR", 1),
+
+    /**
+     * Record only logs below or equal to DEBUG.
+     */
+    DEBUG("DEBUG", 2),
+
+    /**
+     * Record only logs below or equal to WARNING.
+     */
+    WARNING("WARNING", 0);
+
+    /**
+     * The equivalent name of the log level.
+     */
     public final String name;
+
+    /**
+     * The integer value of the log level.
+     */
     public final int id;
 
+    /**
+     * Creates a log level with the integer value.
+     * @param name The name of the log level.
+     * @param id The integer value of the log level.
+     */
     Levels(String name, int id) {
         this.name = name;
         this.id = id;

--- a/src/main/java/pw/mihou/rosedb/enums/Listening.java
+++ b/src/main/java/pw/mihou/rosedb/enums/Listening.java
@@ -47,7 +47,13 @@ public enum Listening {
      * The listener is listening to requests
      * with the method REVERT.
      */
-    REVERT("REVERT");
+    REVERT("REVERT"),
+
+    /**
+     * The listener is listening to requests
+     * with the method COMMAND. (SPECIAL)
+     */
+    COMMAND("COMMAND");
 
     /**
      * The value of the method on the request

--- a/src/main/java/pw/mihou/rosedb/enums/Listening.java
+++ b/src/main/java/pw/mihou/rosedb/enums/Listening.java
@@ -1,11 +1,69 @@
 package pw.mihou.rosedb.enums;
 
+/**
+ * This is where you add more
+ * methods to the list, you can add an enum here
+ * and register it to your listener under type().
+ */
 public enum Listening {
 
-    GET("GET"), DELETE("DELETE"), UPDATE("UPDATE"), ADD("ADD"), DROP("DROP"), AGGREGATE("AGGREGATE"), REVERT("REVERT");
+    /**
+     * The listener is listening to requests
+     * with the method GET.
+     */
+    GET("GET"),
 
+    /**
+     * The listener is listening to requests
+     * with the method DELETE.
+     */
+    DELETE("DELETE"),
+
+    /**
+     * The listener is listening to requests
+     * with the method UPDATE.
+     */
+    UPDATE("UPDATE"),
+
+    /**
+     * The listener is listening to requests
+     * with the method ADD.
+     */
+    ADD("ADD"),
+
+    /**
+     * The listener is listening to requests
+     * with the method DROP.
+     */
+    DROP("DROP"),
+
+    /**
+     * The listener is listening to requests
+     * with the method AGGREGATE.
+     */
+    AGGREGATE("AGGREGATE"),
+
+    /**
+     * The listener is listening to requests
+     * with the method REVERT.
+     */
+    REVERT("REVERT");
+
+    /**
+     * The value of the method on the request
+     * that it should respond to.
+     *
+     * For example, if the request specifically mentions
+     * that the method is GET then all listeners with GET will
+     * respond to it as long as the method matches the GET value here.
+     */
     public final String value;
 
+    /**
+     * Creates a new Listening type.
+     *
+     * @param value The method field value it will respond to.
+     */
     Listening(String value) {
         this.value = value;
     }

--- a/src/main/java/pw/mihou/rosedb/io/FileHandler.java
+++ b/src/main/java/pw/mihou/rosedb/io/FileHandler.java
@@ -8,7 +8,6 @@ import pw.mihou.rosedb.enums.Levels;
 import pw.mihou.rosedb.io.entities.RoseRequest;
 import pw.mihou.rosedb.manager.RoseCollections;
 import pw.mihou.rosedb.manager.RoseDatabase;
-import pw.mihou.rosedb.utility.Pair;
 import pw.mihou.rosedb.utility.Terminal;
 
 import java.io.*;
@@ -16,18 +15,16 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Arrays;
-import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.stream.Collectors;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 
 public class FileHandler {
 
-    private static final ConcurrentLinkedQueue<RoseRequest> queue = new ConcurrentLinkedQueue<>();
+    public static final ConcurrentLinkedQueue<RoseRequest> queue = new ConcurrentLinkedQueue<>();
     private static final AtomicBoolean threadFull = new AtomicBoolean(false);
     private static final FilenameFilter filter = (dir, name) -> name.endsWith(".rose");
     private static String directory;

--- a/src/main/java/pw/mihou/rosedb/io/FileHandler.java
+++ b/src/main/java/pw/mihou/rosedb/io/FileHandler.java
@@ -3,144 +3,87 @@ package pw.mihou.rosedb.io;
 import ch.qos.logback.classic.Level;
 import org.apache.commons.io.FilenameUtils;
 import pw.mihou.rosedb.RoseDB;
-import pw.mihou.rosedb.connections.RoseServer;
 import pw.mihou.rosedb.enums.Levels;
-import pw.mihou.rosedb.io.entities.RoseRequest;
+import pw.mihou.rosedb.io.readers.RoseReader;
+import pw.mihou.rosedb.io.writers.RoseWriter;
 import pw.mihou.rosedb.manager.RoseCollections;
 import pw.mihou.rosedb.manager.RoseDatabase;
 import pw.mihou.rosedb.utility.Terminal;
 
-import java.io.*;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Paths;
+import java.io.File;
+import java.io.FilenameFilter;
 import java.util.Arrays;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
-import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.stream.Collectors;
-import java.util.zip.GZIPInputStream;
-import java.util.zip.GZIPOutputStream;
 
 public class FileHandler {
 
-    public static final ConcurrentLinkedQueue<RoseRequest> queue = new ConcurrentLinkedQueue<>();
-    private static final AtomicBoolean threadFull = new AtomicBoolean(false);
-    private static final FilenameFilter filter = (dir, name) -> name.endsWith(".rose");
-    private static String directory;
+    public static final FilenameFilter filter = (dir, name) -> name.endsWith(".rose");
+    public static String directory;
 
+    /**
+     * Sets the default directory path of the database.
+     *
+     * @param dir the default directory path.
+     */
     public static void setDirectory(String dir) {
         directory = dir;
     }
 
-    public static CompletableFuture<Void> writeToFile(String path, String value) {
-        return write(path, value, false);
-    }
-
-    public static CompletableFuture<Void> writeGzip(String path, String value) {
-        return write(path, value, true);
-    }
-
-    public static CompletableFuture<String> read(String path) {
-        return read(path, false);
-    }
-
-    private static CompletableFuture<String> read(String path, boolean gzip) {
-        return CompletableFuture.supplyAsync(() -> {
-            try (BufferedReader r = (!gzip ? Files.newBufferedReader(Paths.get(path)) :
-                    new BufferedReader(new InputStreamReader(new GZIPInputStream(new FileInputStream(new File(path)), 65536))))) {
-                return r.lines().collect(Collectors.joining("\n"));
-            } catch (IOException e) {
-                Terminal.log(Levels.ERROR, e.getMessage());
-                throw new CompletionException(e);
-            }
-        }, Scheduler.getExecutorService());
-    }
-
-    public static CompletableFuture<String> readGzip(String path) {
-        return read(path, true);
-    }
-
-    public static boolean delete(String database, String collection, String identifier) {
-        queue.stream().filter(roseRequest -> filter(roseRequest, database, collection, identifier)).forEachOrdered(queue::remove);
-        return delete(format(database, collection, identifier));
-    }
-
-    private static boolean delete(String path) {
-        try {
-            return Files.deleteIfExists(Paths.get(path));
-        } catch (IOException exception) {
-            Terminal.log(Levels.ERROR, "An exception occurred while trying to delete: " + exception.getMessage());
-            return false;
-        }
-    }
-
+    /**
+     * Formats the parameters into their correct path.
+     *
+     * @param database The database name.
+     * @param collection The collection name.
+     * @param identifier The identifier name of the item.
+     * @return The full path to the item.
+     */
     public static String format(String database, String collection, String identifier) {
-        return new StringBuilder(directory).append(File.separator).append(database).append(File.separator).append(collection)
-                .append(File.separator).append(identifier).append(".rose").toString();
+        return directory + File.separator + database + File.separator + collection + File.separator + identifier + ".rose";
     }
 
+    /**
+     * Formats the parameters into their correct path.
+     *
+     * @param database The database name.
+     * @param collection The collection name.
+     * @return The full path to the collection.
+     */
     public static String format(String database, String collection) {
-        return new StringBuilder(directory).append(File.separator).append(database).append(File.separator).append(collection).toString();
+        return directory + File.separator + database + File.separator + collection;
     }
 
+    /**
+     * Formats the parameter into its correct path.
+     *
+     * @param database The database name.
+     * @return The full path to the database.
+     */
     public static String format(String database) {
-        return new StringBuilder(directory).append(File.separator).append(database).toString();
+        return directory + File.separator + database;
     }
 
-    private static boolean filter(RoseRequest roseRequest, String database, String collection, String identifier) {
-        return (roseRequest.identifier.equalsIgnoreCase(identifier)
-                && roseRequest.collection.equalsIgnoreCase(collection)
-                && roseRequest.database.equalsIgnoreCase(database));
-    }
-
-    public static void write(String database, String collection, String identifier, String json) {
-        Terminal.log(Levels.DEBUG, "Added to queue: {}/{}/{}.rose: {}", database, collection, identifier, json);
-        queue.add(new RoseRequest(database, collection, identifier, json));
-    }
-
-    public static synchronized void write() {
-        if (!threadFull.get()) {
-            threadFull.set(true);
-
-            while (!queue.isEmpty()) {
-                RoseRequest request = queue.poll();
-                Terminal.log(Levels.DEBUG, "Writing {}/{}/{}.rose: {}", request.database, request.collection, request.identifier, request.json);
-                writeGzip(format(request.database, request.collection, request.identifier), request.json).join();
+    /**
+     * Makes all the directories to the file.
+     *
+     * @param path The full path (including name and extension) of the file.
+     */
+    public static void mkdirs(String path){
+        if(!FilenameUtils.getFullPath(path).isEmpty() && !new File(FilenameUtils.getFullPath(path)).exists()) {
+            if (!new File(FilenameUtils.getFullPath(path)).mkdirs()) {
+                Terminal.setLoggingLevel(Level.ERROR);
+                Terminal.log(Levels.ERROR, "Failed to create folders {}, possibly we do not have permission to write.", FilenameUtils.getFullPath(path));
             }
-
-            threadFull.set(false);
         }
     }
 
-    private static synchronized CompletableFuture<Void> write(String path, String value, boolean gzip) {
-        return CompletableFuture.runAsync(() -> {
-            try {
-                if(!FilenameUtils.getFullPath(path).isEmpty()) {
-                    if (!new File(FilenameUtils.getFullPath(path)).exists()) {
-                        boolean mkdirs = new File(FilenameUtils.getFullPath(path)).mkdirs();
-                        if (!mkdirs) {
-                            Terminal.setLoggingLevel(Level.ERROR);
-                            Terminal.log(Levels.ERROR, "Failed to create folders " + FilenameUtils.getFullPath(path) + ", possibly we do not have permission to write.");
-                        }
-                    }
-                }
-
-                if (!gzip) {
-                    Files.writeString(Paths.get(path), value, StandardCharsets.UTF_8);
-                } else {
-                    try (BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(new GZIPOutputStream(new FileOutputStream(new File(path)), 65536)))) {
-                        writer.write(value);
-                    }
-                }
-            } catch (IOException e) {
-                Terminal.log(Levels.ERROR, e.getMessage());
-            }
-        });
-    }
-
+    /**
+     * Reads an entire collection and all the items inside the collection.
+     *
+     * @param database The database that holds the collection.
+     * @param collection The name of the collection.
+     * @return The entire collection and its items.
+     */
     public static CompletableFuture<RoseCollections> readCollection(String database, String collection) {
         return CompletableFuture.supplyAsync(() -> {
             String location = format(database, collection);
@@ -158,27 +101,37 @@ public class FileHandler {
             RoseCollections collections = new RoseCollections(collection, database);
 
             if (contents != null) {
-                Arrays.stream(contents).forEach(file -> collections.cache(FilenameUtils.getBaseName(file.getName()), readGzip(file.getPath()).join()));
+                Arrays.stream(contents).forEach(file -> collections.cache(FilenameUtils.getBaseName(file.getName()), RoseReader.readGZIP(file.getPath()).join()));
             }
             return collections;
         }, Scheduler.getExecutorService());
     }
 
+    /**
+     * Reads a backup version if it exists, or else returns empty.
+     *
+     * @param database The database where the backup is from.
+     * @param collection The collection where the backup is from.
+     * @param identifier The identifier of the item to be read.
+     * @return The older version of the item, if it exists.
+     */
     public static Optional<String> readVersion(String database, String collection, String identifier) {
-        String location = new StringBuilder(".rose_versions")
-                .append(File.separator)
-                .append(database)
-                .append(File.separator).append(collection)
-                .append(File.separator).append(identifier)
-                .append(".rose").toString();
+        String location = ".rose_versions" + File.separator + database + File.separator + collection +
+                File.separator + identifier + ".rose";
 
         if (!new File(location).exists()) {
             return Optional.empty();
         }
 
-        return Optional.of(readGzip(new File(location).getPath()).join());
+        return Optional.of(RoseReader.readGZIP(new File(location).getPath()).join());
     }
 
+    /**
+     * Reads an entire database including its collections and items.
+     *
+     * @param database The database to read.
+     * @return An entire database with its collections (that contains all the items).
+     */
     public static CompletableFuture<RoseDatabase> readDatabase(String database) {
         return CompletableFuture.supplyAsync(() -> {
             String location = format(database);
@@ -204,66 +157,82 @@ public class FileHandler {
         }, Scheduler.getExecutorService());
     }
 
+    /**
+     * Reads an independent item from a collection if it exists.
+     *
+     * @param database The database where the item is located.
+     * @param collection The collection where the item is located.
+     * @param identifier The item's identifier.
+     * @return The value of the item, if it exists.
+     */
     public static Optional<String> readData(String database, String collection, String identifier) {
         Terminal.log(Levels.DEBUG, "Attempting to read {}/{}/{}.rose", database, collection, identifier);
         String location = format(database, collection, identifier);
         if (!new File(location).exists())
             return Optional.empty();
 
-        return Optional.of(readGzip(location).join());
+        return Optional.of(RoseReader.readGZIP(location).join());
     }
 
-    public static CompletableFuture<Void> preloadAll() {
-        return CompletableFuture.runAsync(() -> {
-            File[] contents = new File(RoseDB.directory).listFiles();
+    /**
+     * Preloads all the databases, collections and items inside the directory.
+     */
+    public static void preloadAll() {
+        File[] contents = new File(RoseDB.directory).listFiles();
 
-            if (contents != null) {
-                Arrays.stream(contents).filter(File::isDirectory)
-                        .forEachOrdered(file -> RoseServer.getDatabase(FilenameUtils.getBaseName(file.getName())));
-            }
-        }, Scheduler.getExecutorService());
+        if (contents != null) {
+            Arrays.stream(contents).filter(File::isDirectory)
+                    .forEachOrdered(file -> RoseDatabase.getDatabase(FilenameUtils.getBaseName(file.getName())));
+        }
     }
 
-    public static CompletableFuture<Void> migrateAll() {
-        return CompletableFuture.runAsync(() -> {
-            File[] contents = new File(directory).listFiles();
+    /**
+     * Migrates all older versions of Rose (that used raw JSON as value)
+     * to the newer format which wraps the JSON in GZIP for smaller size.
+     */
+    public static void migrateAll() {
+        File[] contents = new File(directory).listFiles();
 
-            if (contents != null) {
-                Arrays.stream(contents).filter(File::isDirectory).forEachOrdered(file -> {
-                    File[] c = new File(format(FilenameUtils.getBaseName(file.getName()))).listFiles();
+        if (contents != null) {
+            Arrays.stream(contents).filter(File::isDirectory).forEachOrdered(file -> {
+                File[] c = new File(format(FilenameUtils.getBaseName(file.getName()))).listFiles();
 
-                    if (c != null) {
-                        Arrays.stream(c).filter(File::isDirectory)
-                                .forEachOrdered(d -> migrateCollection(FilenameUtils.getBaseName(file.getName()),
-                                        FilenameUtils.getBaseName(d.getName())));
-                    }
-                });
-            }
-        }, Scheduler.getExecutorService());
+                if (c != null) {
+                    Arrays.stream(c).filter(File::isDirectory)
+                            .forEachOrdered(d -> migrateCollection(FilenameUtils.getBaseName(file.getName()),
+                                    FilenameUtils.getBaseName(d.getName())));
+                }
+            });
+        }
     }
 
-    public static CompletableFuture<Void> migrateCollection(String database, String collection) {
-        return CompletableFuture.runAsync(() -> {
+    /**
+     * Migrates an entire collection's items from raw JSON values
+     * to Gzipped JSON values.
+     *
+     * @param database The database where the collection is located.
+     * @param collection The name of the collection.
+     */
+    public static void migrateCollection(String database, String collection) {
+        CompletableFuture.runAsync(() -> {
             Terminal.log(Levels.INFO, "Attempting to migrate " + collection + " from " + database + " to newer format.");
             File[] contents = new File(format(database, collection)).listFiles(filter);
 
             if (contents != null) {
                 Arrays.stream(contents).map(File::getPath)
-                .forEachOrdered(path -> {
-                    read(path, false).thenAccept(s -> {
-                        if (s != null && s.isEmpty() && s.isBlank()) {
-                            writeGzip(path, s);
-                        }
-                    }).exceptionally(throwable -> {
-                        if (throwable != null) {
-                            Terminal.log.error("An error occurred while trying to write on {} this usually happens if you are trying to migrate from" +
-                                    " v1.1 to > v1.2 version with > v1.2 version data, please move the Database folder first before retrying then after configuration is updated, " +
-                                    "you may add the Database folder again.", path);
-                            Terminal.log.error(throwable.getMessage());
-                        }
-                        return null;
-                    });
-                });
+                .forEachOrdered(path -> RoseReader.read(path).thenAccept(s -> {
+                    if (s != null && s.isEmpty() && s.isBlank()) {
+                        RoseWriter.writeGZIP(path, s);
+                    }
+                }).exceptionally(throwable -> {
+                    if (throwable != null) {
+                        Terminal.log.error("An error occurred while trying to write on {} this usually happens if you are trying to migrate from" +
+                                " v1.1 to > v1.2 version with > v1.2 version data, please move the Database folder first before retrying then after configuration is updated, " +
+                                "you may add the Database folder again.", path);
+                        Terminal.log.error(throwable.getMessage());
+                    }
+                    return null;
+                }));
             }
         });
     }

--- a/src/main/java/pw/mihou/rosedb/io/FileHandler.java
+++ b/src/main/java/pw/mihou/rosedb/io/FileHandler.java
@@ -120,6 +120,15 @@ public class FileHandler {
     private static synchronized CompletableFuture<Void> write(String path, String value, boolean gzip) {
         return CompletableFuture.runAsync(() -> {
             try {
+
+                if (!new File(path).getParentFile().exists()) {
+                    boolean mkdirs = new File(path).getParentFile().mkdirs();
+                    if (!mkdirs) {
+                        Terminal.setLoggingLevel(Level.ERROR);
+                        Terminal.log(Levels.ERROR, "Failed to create folders for " + path + ", possibly we do not have permission to write.");
+                    }
+                }
+
                 if (!gzip) {
                     Files.writeString(Paths.get(path), value, StandardCharsets.UTF_8);
                 } else {

--- a/src/main/java/pw/mihou/rosedb/io/RoseQuery.java
+++ b/src/main/java/pw/mihou/rosedb/io/RoseQuery.java
@@ -1,0 +1,51 @@
+package pw.mihou.rosedb.io;
+
+import org.json.JSONObject;
+import pw.mihou.rosedb.RoseDB;
+import pw.mihou.rosedb.io.entities.QueryRequest;
+
+public class RoseQuery {
+
+    public static QueryRequest parse(String message){
+        try {
+            String[] context = message.split("\\.");
+            QueryRequest request = new QueryRequest();
+            if (context.length > 2) {
+                request.database = context[0];
+                request.collection = context[1];
+                request.method = context[2].substring(0, context[2].indexOf("("));
+                if (!context[2].endsWith("()")) {
+                    String item = context[2].replaceFirst(request.method + "\\(", "");
+                    item = item.substring(0, !item.contains(", ") ? item.indexOf(")") : item.indexOf(", "));
+                    request.identifier = item;
+                    if(context[2].contains(", ")) {
+                        String req = context[2].replaceFirst(request.method + "\\(" + item + ", ", "");
+                        req = req.substring(0, req.length() - 1);
+                        request.value = req;
+                    }
+                }
+            } else {
+                request.database = context[0];
+                request.method = context[1].substring(0, context[1].indexOf("("));
+                if (!context[1].endsWith("()")) {
+                    String item = context[1].replaceFirst(request.method + "\\(", "");
+                    item = item.substring(0, !item.contains(", ") ? item.indexOf(")") : item.indexOf(", "));
+                    request.identifier = item;
+                    if(context[1].contains(", ")) {
+                        String req = context[1].replaceFirst(request.method + "\\(" + item + ", ", "");
+                        req = req.substring(0, req.length() - 1);
+                        request.value = req;
+                    }
+                }
+            }
+            return request;
+        } catch (IndexOutOfBoundsException e){
+            return new QueryRequest();
+        }
+    }
+
+    public static QueryRequest parse(JSONObject object){
+        return RoseDB.gson.fromJson(object.toString(), QueryRequest.class);
+    }
+
+}

--- a/src/main/java/pw/mihou/rosedb/io/RoseQuery.java
+++ b/src/main/java/pw/mihou/rosedb/io/RoseQuery.java
@@ -19,10 +19,10 @@ public class RoseQuery {
             if (context.length > 2) {
                 request.database = context[0];
                 request.collection = context[1];
-                request.method = context[2].substring(0, context[2].indexOf("("));
+                request.method = context[2].substring(0, context[2].indexOf('('));
                 if (!context[2].endsWith("()")) {
                     String item = context[2].replaceFirst(request.method + "\\(", "");
-                    item = item.substring(0, !item.contains(", ") ? item.indexOf(")") : item.indexOf(", "));
+                    item = item.substring(0, !item.contains(", ") ? item.indexOf(')') : item.indexOf(", "));
                     request.identifier = item;
                     if(context[2].contains(", ")) {
                         String req = context[2].replaceFirst(request.method + "\\(" + item + ", ", "");
@@ -32,10 +32,10 @@ public class RoseQuery {
                 }
             } else {
                 request.database = context[0];
-                request.method = context[1].substring(0, context[1].indexOf("("));
+                request.method = context[1].substring(0, context[1].indexOf('('));
                 if (!context[1].endsWith("()")) {
                     String item = context[1].replaceFirst(request.method + "\\(", "");
-                    item = item.substring(0, !item.contains(", ") ? item.indexOf(")") : item.indexOf(", "));
+                    item = item.substring(0, !item.contains(", ") ? item.indexOf(')') : item.indexOf(", "));
                     request.identifier = item;
                     if(context[1].contains(", ")) {
                         String req = context[1].replaceFirst(request.method + "\\(" + item + ", ", "");

--- a/src/main/java/pw/mihou/rosedb/io/RoseQuery.java
+++ b/src/main/java/pw/mihou/rosedb/io/RoseQuery.java
@@ -27,7 +27,10 @@ public class RoseQuery {
                     if(context[2].contains(", ")) {
                         String req = context[2].replaceFirst(request.method + "\\(" + item + ", ", "");
                         req = req.substring(0, req.length() - 1);
-                        request.value = req;
+                        JSONObject res = new JSONObject(req);
+                        request.unique = res.optString("unique", "");
+                        res.remove("unique");
+                        request.value = res.toString();
                     }
                 }
             } else {
@@ -40,7 +43,10 @@ public class RoseQuery {
                     if(context[1].contains(", ")) {
                         String req = context[1].replaceFirst(request.method + "\\(" + item + ", ", "");
                         req = req.substring(0, req.length() - 1);
-                        request.value = req;
+                        JSONObject res = new JSONObject(req);
+                        request.unique = res.optString("unique", "");
+                        res.remove("unique");
+                        request.value = res.toString();
                     }
                 }
             }

--- a/src/main/java/pw/mihou/rosedb/io/RoseQuery.java
+++ b/src/main/java/pw/mihou/rosedb/io/RoseQuery.java
@@ -6,6 +6,12 @@ import pw.mihou.rosedb.io.entities.QueryRequest;
 
 public class RoseQuery {
 
+    /**
+     * Parses the message into Query Request.
+     *
+     * @param message The message to parse.
+     * @return The Query request parsed (usually every value is null inside if invalid).
+     */
     public static QueryRequest parse(String message){
         try {
             String[] context = message.split("\\.");
@@ -44,6 +50,12 @@ public class RoseQuery {
         }
     }
 
+    /**
+     * Parses a JSONObject into Queria's Query Request.
+     *
+     * @param object The JSON Object to parse.
+     * @return The Query request parsed (usually every value is null inside if invalid).
+     */
     public static QueryRequest parse(JSONObject object){
         return RoseDB.gson.fromJson(object.toString(), QueryRequest.class);
     }

--- a/src/main/java/pw/mihou/rosedb/io/deleter/RoseDeleter.java
+++ b/src/main/java/pw/mihou/rosedb/io/deleter/RoseDeleter.java
@@ -1,0 +1,70 @@
+package pw.mihou.rosedb.io.deleter;
+
+import org.apache.commons.io.FileUtils;
+import pw.mihou.rosedb.RoseDB;
+import pw.mihou.rosedb.enums.Levels;
+import pw.mihou.rosedb.io.FileHandler;
+import pw.mihou.rosedb.io.entities.RoseRequest;
+import pw.mihou.rosedb.io.writers.RoseWriter;
+import pw.mihou.rosedb.utility.Terminal;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+public class RoseDeleter {
+
+    public static void delete(String database, String collection, String identifier){
+        RoseWriter.queue.stream().filter(roseRequest -> filter(roseRequest, database, collection, identifier))
+                .forEachOrdered(RoseWriter.queue::remove);
+        delete(FileHandler.format(database, collection, identifier), 0);
+    }
+
+    public static void deleteDirectory(File directory, int fails){
+        try {
+            FileUtils.deleteDirectory(directory);
+        } catch (IOException exception) {
+            if(fails < 10) {
+                Terminal.log(Levels.ERROR, "Attempt to delete directory file ({}) was stopped by an IOException ({}), retrying attempt...",
+                        directory.getPath(),
+                        exception.getMessage());
+                try {
+                    Thread.sleep(500);
+                } catch (InterruptedException e) {
+                    Terminal.log(Levels.ERROR, "Attempt to delete file ({}) was stopped by InterruptedException ({}), forcing retry.",
+                            directory.getPath(),
+                            e.getMessage());
+                }
+                deleteDirectory(directory, fails + 1);
+            }
+        } catch (IllegalArgumentException e) {
+            Terminal.log(Levels.ERROR, "Attempt to delete file ({}) was stopped by IllegalArgumentException ({}).", directory.getPath(), e.getMessage());
+        }
+    }
+
+    public static void delete(String path, int fails){
+        try {
+            Files.deleteIfExists(Paths.get(path));
+        } catch (IOException e){
+            if(fails < 10) {
+                Terminal.log(Levels.DEBUG, "Attempt to delete file ({}) was stopped by an IOException ({}), retrying attempt...", path, e.getMessage());
+                try {
+                    Thread.sleep(500);
+                } catch (InterruptedException interruptedException) {
+                    Terminal.log(Levels.ERROR, "Attempt to delete file ({}) was stopped by InterruptedException ({}), forcing retry.", path, interruptedException.getMessage());
+                }
+                delete(path, fails + 1);
+            } else {
+                Terminal.log(Levels.ERROR, "An exception occurred while trying to delete: {}", e.getMessage());
+            }
+        }
+    }
+
+    private static boolean filter(RoseRequest roseRequest, String database, String collection, String identifier) {
+        return (roseRequest.identifier.equalsIgnoreCase(identifier)
+                && roseRequest.collection.equalsIgnoreCase(collection)
+                && roseRequest.database.equalsIgnoreCase(database));
+    }
+
+}

--- a/src/main/java/pw/mihou/rosedb/io/deleter/RoseDeleter.java
+++ b/src/main/java/pw/mihou/rosedb/io/deleter/RoseDeleter.java
@@ -1,7 +1,6 @@
 package pw.mihou.rosedb.io.deleter;
 
 import org.apache.commons.io.FileUtils;
-import pw.mihou.rosedb.RoseDB;
 import pw.mihou.rosedb.enums.Levels;
 import pw.mihou.rosedb.io.FileHandler;
 import pw.mihou.rosedb.io.entities.RoseRequest;

--- a/src/main/java/pw/mihou/rosedb/io/deleter/RoseDeleter.java
+++ b/src/main/java/pw/mihou/rosedb/io/deleter/RoseDeleter.java
@@ -1,61 +1,86 @@
 package pw.mihou.rosedb.io.deleter;
 
+import journal.io.api.Journal;
+import journal.io.api.Location;
 import org.apache.commons.io.FileUtils;
+import pw.mihou.rosedb.RoseDB;
 import pw.mihou.rosedb.enums.Levels;
 import pw.mihou.rosedb.io.FileHandler;
 import pw.mihou.rosedb.io.entities.RoseRequest;
 import pw.mihou.rosedb.io.writers.RoseWriter;
+import pw.mihou.rosedb.utility.Pair;
 import pw.mihou.rosedb.utility.Terminal;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.function.Predicate;
 
 public class RoseDeleter {
 
-    public static void delete(String database, String collection, String identifier){
-        RoseWriter.queue.stream().filter(roseRequest -> filter(roseRequest, database, collection, identifier))
-                .forEachOrdered(RoseWriter.queue::remove);
-        delete(FileHandler.format(database, collection, identifier), 0);
-    }
-
-    public static void deleteDirectory(File directory, int fails){
+    public static Pair<Boolean, String> delete(String database, String collection, String identifier){
         try {
-            FileUtils.deleteDirectory(directory);
-        } catch (IOException exception) {
-            if(fails < 10) {
-                Terminal.log(Levels.ERROR, "Attempt to delete directory file ({}) was stopped by an IOException ({}), retrying attempt...",
-                        directory.getPath(),
-                        exception.getMessage());
-                try {
-                    Thread.sleep(500);
-                } catch (InterruptedException e) {
-                    Terminal.log(Levels.ERROR, "Attempt to delete file ({}) was stopped by InterruptedException ({}), forcing retry.",
-                            directory.getPath(),
-                            e.getMessage());
-                }
-                deleteDirectory(directory, fails + 1);
+            for (Location location : RoseDB.journal.redo()) {
+                RoseRequest request = RoseDB.gson.fromJson(new String(RoseDB.journal.read(location, Journal.ReadType.SYNC)), RoseRequest.class);
+                if(filter(request, database, collection, identifier))
+                    RoseDB.journal.delete(location);
             }
-        } catch (IllegalArgumentException e) {
-            Terminal.log(Levels.ERROR, "Attempt to delete file ({}) was stopped by IllegalArgumentException ({}).", directory.getPath(), e.getMessage());
+            RoseDB.journal.sync();
+            RoseDB.journal.compact();
+            return delete(FileHandler.format(database, collection, identifier));
+        } catch (IOException exception) {
+            Terminal.log(Levels.ERROR, "Rose Writer has returned an exception : {}", exception.getMessage());
+            return Pair.of(false, exception.getMessage());
         }
     }
 
-    public static void delete(String path, int fails){
+    public static boolean cleanJournal(Predicate<RoseRequest> predicate){
         try {
-            Files.deleteIfExists(Paths.get(path));
-        } catch (IOException e){
-            if(fails < 10) {
-                Terminal.log(Levels.DEBUG, "Attempt to delete file ({}) was stopped by an IOException ({}), retrying attempt...", path, e.getMessage());
-                try {
-                    Thread.sleep(500);
-                } catch (InterruptedException interruptedException) {
-                    Terminal.log(Levels.ERROR, "Attempt to delete file ({}) was stopped by InterruptedException ({}), forcing retry.", path, interruptedException.getMessage());
-                }
-                delete(path, fails + 1);
-            } else {
+            for (Location location : RoseDB.journal.redo()) {
+                RoseRequest request = RoseDB.gson.fromJson(new String(RoseDB.journal.read(location, Journal.ReadType.SYNC)), RoseRequest.class);
+                if(predicate.test(request))
+                    RoseDB.journal.delete(location);
+            }
+            RoseDB.journal.sync();
+            RoseDB.journal.compact();
+            return true;
+        } catch (IOException exception) {
+            Terminal.log(Levels.ERROR, "Rose Writer has returned an exception : {}", exception.getMessage());
+            return false;
+        }
+    }
+
+    public static Pair<Boolean, String> deleteDirectory(File directory){
+        try {
+            FileUtils.deleteDirectory(directory);
+            return Pair.of(true, "The directory was successfully removed.");
+        } catch (IOException exception) {
+            Terminal.log(Levels.DEBUG, "Attempt to delete file ({}) was stopped by an IOException ({}), retrying attempt...", directory.getPath(), exception.getMessage());
+            try {
+                return RoseDB.retry.executeCallable(() -> deleteDirectory(directory));
+            } catch (Exception e) {
                 Terminal.log(Levels.ERROR, "An exception occurred while trying to delete: {}", e.getMessage());
+                return Pair.of(false, exception.getMessage());
+            }
+        } catch (IllegalArgumentException e) {
+            Terminal.log(Levels.ERROR, "Attempt to delete file ({}) was stopped by IllegalArgumentException ({}).", directory.getPath(), e.getMessage());
+            return Pair.of(false, e.getMessage());
+        }
+    }
+
+    public static Pair<Boolean, String> delete(String path){
+        try {
+            boolean val = Files.deleteIfExists(Paths.get(path));
+            return Pair.of(val, val ? "The file/directory was deleted successfully." : "Attempt to delete file or directory was stopped, " +
+                    "either because the file didn't exist or external reasons.");
+        } catch (IOException e){
+            Terminal.log(Levels.DEBUG, "Attempt to delete file ({}) was stopped by an IOException ({}), retrying attempt...", path, e.getMessage());
+            try {
+                return RoseDB.retry.executeCallable(() -> delete(path));
+            } catch (Exception exception) {
+                Terminal.log(Levels.ERROR, "An exception occurred while trying to delete: {}", exception.getMessage());
+                return Pair.of(false, exception.getMessage());
             }
         }
     }

--- a/src/main/java/pw/mihou/rosedb/io/entities/QueryRequest.java
+++ b/src/main/java/pw/mihou/rosedb/io/entities/QueryRequest.java
@@ -5,25 +5,68 @@ import pw.mihou.rosedb.RoseDB;
 
 public class QueryRequest {
 
+    /**
+     * The database from the request.
+     * This should never be null if the syntax is really of Queria.
+     */
     public String database;
+
+    /**
+     * The collection from the request.
+     * This is usually null in cases like database.aggregate()
+     * or database.drop().
+     */
     public String collection;
+
+    /**
+     * The identifier of the item from the request.
+     * This is usually null especially in cases like .aggregate().
+     */
     public String identifier;
+
+    /**
+     * The method to use from the request.
+     * This should never be null unless the request is not of Queria.
+     */
     public String method;
+
+    /**
+     * The value from the request.
+     * This is sometimes null especially in cases like .get(item) or
+     * .aggregate() or drop(item)
+     */
     public String value;
+
+    /**
+     * The unique callback from the request.
+     * This is usually empty if it comes from terminal.
+     */
     public String unique = "";
 
+    /**
+     * Checks if the query result is valid.
+     * This involves checking if database value and method value is not null.
+     *
+     * @return Whether the Query Result is of valid Queria syntax.
+     */
     public boolean isValid(){
         return database != null && method != null;
     }
 
-    public boolean isComplete(){
-        return database != null && collection != null && identifier != null && method != null && value != null;
-    }
-
+    /**
+     * Parses the request into JSONObject.
+     *
+     * @return A JSONObject variant of the request.
+     */
     public JSONObject asJSONObject(){
         return new JSONObject(RoseDB.gson.toJson(this));
     }
 
+    /**
+     * Converts only the value into JSON Object.
+     *
+     * @return A JSONObject containing only the value of the request.
+     */
     public JSONObject valueAsJSONObject(){
         return new JSONObject(value);
     }

--- a/src/main/java/pw/mihou/rosedb/io/entities/QueryRequest.java
+++ b/src/main/java/pw/mihou/rosedb/io/entities/QueryRequest.java
@@ -1,0 +1,31 @@
+package pw.mihou.rosedb.io.entities;
+
+import org.json.JSONObject;
+import pw.mihou.rosedb.RoseDB;
+
+public class QueryRequest {
+
+    public String database;
+    public String collection;
+    public String identifier;
+    public String method;
+    public String value;
+    public String unique = "";
+
+    public boolean isValid(){
+        return database != null && method != null;
+    }
+
+    public boolean isComplete(){
+        return database != null && collection != null && identifier != null && method != null && value != null;
+    }
+
+    public JSONObject asJSONObject(){
+        return new JSONObject(RoseDB.gson.toJson(this));
+    }
+
+    public JSONObject valueAsJSONObject(){
+        return new JSONObject(value);
+    }
+
+}

--- a/src/main/java/pw/mihou/rosedb/io/entities/RoseRequest.java
+++ b/src/main/java/pw/mihou/rosedb/io/entities/RoseRequest.java
@@ -64,4 +64,16 @@ public class RoseRequest {
         return this.request;
     }
 
+    /**
+     * Compares the two requests to figure out whether they are
+     * heading to the same item or file.
+     *
+     * @param request The request to compare.
+     * @return Are they heading to the same file?
+     */
+    public boolean compare(RoseRequest request){
+        return identifier.equals(request.identifier) && database.equals(request.database) &&
+                collection.equals(request.collection);
+    }
+
 }

--- a/src/main/java/pw/mihou/rosedb/io/entities/RoseRequest.java
+++ b/src/main/java/pw/mihou/rosedb/io/entities/RoseRequest.java
@@ -11,6 +11,13 @@ public class RoseRequest {
     public String identifier;
     private Map<String, String> request;
 
+    /**
+     * Creates a Rose Request with a key-value request.
+     * @param database The database where the item is held.
+     * @param collection The collection where the item is held.
+     * @param identifier The identifier of the item.
+     * @param request The key-value request.
+     */
     public RoseRequest(String database, String collection, String identifier, Map<String, String> request) {
         this.request = request;
         this.database = database;
@@ -18,6 +25,13 @@ public class RoseRequest {
         this.identifier = identifier;
     }
 
+    /**
+     * Creates a Rose Request with a String request which is usually a JSON value.
+     * @param database The database where the item is held.
+     * @param collection The collection where the item is held.
+     * @param identifier The identifier of the item.
+     * @param request The JSON value inside the item.
+     */
     public RoseRequest(String database, String collection, String identifier, String request) {
         this.json = request;
         this.database = database;
@@ -25,6 +39,14 @@ public class RoseRequest {
         this.identifier = identifier;
     }
 
+    /**
+     * Creates a key-value Rose Request.
+     * @param database The database where the item is held.
+     * @param collection The collection where the item is held.
+     * @param identifier The identifier of the itme.
+     * @param key The key of the value.
+     * @param value The value of the key.
+     */
     public RoseRequest(String database, String collection, String identifier, String key, String value) {
         this.request = new HashMap<>();
         request.put(key, value);
@@ -33,6 +55,11 @@ public class RoseRequest {
         this.identifier = identifier;
     }
 
+    /**
+     * Retrieves the key-value request.
+     *
+     * @return The key-value map.
+     */
     public Map<String, String> getRequest() {
         return this.request;
     }

--- a/src/main/java/pw/mihou/rosedb/io/internals/InternalLocks.java
+++ b/src/main/java/pw/mihou/rosedb/io/internals/InternalLocks.java
@@ -1,0 +1,97 @@
+package pw.mihou.rosedb.io.internals;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * A locking mechanism that is used to internally lock a file.
+ * This is used to check if a thread is writing to a file or not.
+ *
+ * And if a thread is already writing to a file, anything that attempts
+ * to read the file will wait until the lock is freed before attempting a read.
+ *
+ * This does not prevent other processes from accessing our files
+ * but it keeps our threads in sync.
+ */
+public class InternalLocks {
+
+    /**
+     * The lock holder, this holds all the internal locks' state.
+     * The string is the path to the lock. If the path to the file is
+     * on here then it means a thread is currently writing to the file.
+     */
+    private static final List<String> writeLocks = Collections.synchronizedList(new ArrayList<>());
+    private static final Map<String, AtomicInteger> readLocks = new ConcurrentHashMap<>();
+
+    /**
+     * Locks the file for internal writing, this prevents any
+     * writers from writing to the file if a thread is currently reading
+     * the file.
+     *
+     * @param path The path to the file.
+     * @throws FileLockedException If a thread is currently writing or reading a file, the method will throw
+     * this exception to let the thread know and wait.
+     */
+    public static synchronized void lock(String path) throws FileLockedException {
+        if(writeLocks.contains(path) || readLocks.containsKey(path) && readLocks.get(path).get() > 0)
+            throw new FileLockedException();
+
+        writeLocks.add(path);
+    }
+
+    /**
+     * Locks the file for internal reading, this prevents any writers
+     * from writing to the file until a thread is finished reading the
+     * file.
+     *
+     * @param path The path to the file.
+     * @throws FileLockedException If a thread is currently writing or reading a file, this
+     * method will throw this exception.
+     */
+    public static synchronized void lockRead(String path) throws FileLockedException {
+        if(writeLocks.contains(path))
+            throw new FileLockedException();
+
+        if(readLocks.containsKey(path))
+            readLocks.get(path).addAndGet(1);
+        else
+            readLocks.put(path, new AtomicInteger(1));
+    }
+
+    /**
+     * Releases the lock for the file, this will only release
+     * the internal thread-lock.
+     *
+     * @param path The path to the file.
+     */
+    public static synchronized void release(String path) {
+        writeLocks.remove(path);
+    }
+
+    /**
+     * Releases the lock for the file, this will only release
+     * the internal thread-lock for reads.
+     *
+     * @param path The path to the file.
+     */
+    public static synchronized void releaseRead(String path) {
+        if(readLocks.containsKey(path))
+            if(readLocks.get(path).get() > 1)
+                readLocks.get(path).decrementAndGet();
+            else
+                readLocks.remove(path);
+    }
+
+    public static class FileLockedException extends Exception {
+
+        public FileLockedException(){
+            super("The file is currently locked by another thread, please try again later.");
+        }
+
+    }
+
+}

--- a/src/main/java/pw/mihou/rosedb/io/readers/RoseReader.java
+++ b/src/main/java/pw/mihou/rosedb/io/readers/RoseReader.java
@@ -1,5 +1,6 @@
 package pw.mihou.rosedb.io.readers;
 
+import pw.mihou.rosedb.RoseDB;
 import pw.mihou.rosedb.enums.Levels;
 import pw.mihou.rosedb.io.Scheduler;
 import pw.mihou.rosedb.io.internals.InternalLocks;
@@ -15,14 +16,14 @@ import java.util.zip.GZIPInputStream;
 public class RoseReader {
 
     public synchronized static CompletableFuture<String> readGZIP(String path){
-        return CompletableFuture.supplyAsync(() -> read(path, true, 0), Scheduler.getExecutorService());
+        return CompletableFuture.supplyAsync(() -> read(path, true), Scheduler.getExecutorService());
     }
 
     public synchronized static CompletableFuture<String> read(String path){
-        return CompletableFuture.supplyAsync(() -> read(path, false, 0), Scheduler.getExecutorService());
+        return CompletableFuture.supplyAsync(() -> read(path, false), Scheduler.getExecutorService());
     }
 
-    private synchronized static String read(String path, boolean gzip, int fails){
+    private synchronized static String read(String path, boolean gzip){
         if(!new File(path).exists() || !new File(path).canRead()){
             Terminal.log(Levels.ERROR, "An error occurred while trying to read {}, we either don't have permission to read file or the file does not exist.");
             return null;
@@ -30,22 +31,16 @@ public class RoseReader {
 
         try {
             try (BufferedReader reader = (!gzip ? Files.newBufferedReader(Paths.get(path)) :
-                    new BufferedReader(new InputStreamReader(new GZIPInputStream(new FileInputStream(new File(path)), 65536))))) {
+                    new BufferedReader(new InputStreamReader(new GZIPInputStream(new FileInputStream(new File(path)), 8192))))) {
                 InternalLocks.lockRead(path);
                 return reader.lines().collect(Collectors.joining("\n"));
             } catch (InternalLocks.FileLockedException e) {
-                if(fails < 100) {
-                    Terminal.log(Levels.DEBUG, "Lock for {} was already acquired by JVM, thread will retry in awhile.", path);
-                    Thread.sleep(50);
-                    return read(path, gzip, fails + 1);
-                } else {
-                    Terminal.log(Levels.ERROR, "Unable to retrieve lock for {} after interval time: {}", path, e.getMessage());
-                    return null;
-                }
+                Terminal.log(Levels.DEBUG, "Lock for {} was already acquired by JVM, thread will retry in awhile.", path);
+                return read(path, gzip);
             } finally {
                 InternalLocks.releaseRead(path);
             }
-        } catch (IOException | InterruptedException e){
+        } catch (Exception e){
             Terminal.log(Levels.ERROR, "An error occurred while trying to write {}: {}", path, e.getMessage());
         }
         return null;

--- a/src/main/java/pw/mihou/rosedb/io/readers/RoseReader.java
+++ b/src/main/java/pw/mihou/rosedb/io/readers/RoseReader.java
@@ -1,0 +1,54 @@
+package pw.mihou.rosedb.io.readers;
+
+import pw.mihou.rosedb.enums.Levels;
+import pw.mihou.rosedb.io.Scheduler;
+import pw.mihou.rosedb.io.internals.InternalLocks;
+import pw.mihou.rosedb.utility.Terminal;
+
+import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+import java.util.zip.GZIPInputStream;
+
+public class RoseReader {
+
+    public synchronized static CompletableFuture<String> readGZIP(String path){
+        return CompletableFuture.supplyAsync(() -> read(path, true, 0), Scheduler.getExecutorService());
+    }
+
+    public synchronized static CompletableFuture<String> read(String path){
+        return CompletableFuture.supplyAsync(() -> read(path, false, 0), Scheduler.getExecutorService());
+    }
+
+    private synchronized static String read(String path, boolean gzip, int fails){
+        if(!new File(path).exists() || !new File(path).canRead()){
+            Terminal.log(Levels.ERROR, "An error occurred while trying to read {}, we either don't have permission to read file or the file does not exist.");
+            return null;
+        }
+
+        try {
+            try (BufferedReader reader = (!gzip ? Files.newBufferedReader(Paths.get(path)) :
+                    new BufferedReader(new InputStreamReader(new GZIPInputStream(new FileInputStream(new File(path)), 65536))))) {
+                InternalLocks.lockRead(path);
+                return reader.lines().collect(Collectors.joining("\n"));
+            } catch (InternalLocks.FileLockedException e) {
+                if(fails < 100) {
+                    Terminal.log(Levels.DEBUG, "Lock for {} was already acquired by JVM, thread will retry in awhile.", path);
+                    Thread.sleep(50);
+                    return read(path, gzip, fails + 1);
+                } else {
+                    Terminal.log(Levels.ERROR, "Unable to retrieve lock for {} after interval time: {}", path, e.getMessage());
+                    return null;
+                }
+            } finally {
+                InternalLocks.releaseRead(path);
+            }
+        } catch (IOException | InterruptedException e){
+            Terminal.log(Levels.ERROR, "An error occurred while trying to write {}: {}", path, e.getMessage());
+        }
+        return null;
+    }
+
+}

--- a/src/main/java/pw/mihou/rosedb/io/writers/RoseWriter.java
+++ b/src/main/java/pw/mihou/rosedb/io/writers/RoseWriter.java
@@ -3,6 +3,7 @@ package pw.mihou.rosedb.io.writers;
 import journal.io.api.Journal;
 import journal.io.api.Location;
 import pw.mihou.rosedb.RoseDB;
+import pw.mihou.rosedb.connections.RoseServer;
 import pw.mihou.rosedb.enums.Levels;
 import pw.mihou.rosedb.io.FileHandler;
 import pw.mihou.rosedb.io.Scheduler;
@@ -60,6 +61,14 @@ public class RoseWriter {
                     write(FileHandler.format(request.database, request.collection, request.identifier), request.json, true).join();
                 else
                     write(FileHandler.format(request.database, request.collection, request.identifier), request.json, true);
+            }
+
+            if(!RoseServer.isOpen) {
+                try {
+                    RoseDB.journal.close();
+                } catch (IOException exception) {
+                    Terminal.log(Levels.ERROR, "Attempt to close journal was met with {}", exception.getMessage());
+                }
             }
         } catch (IOException exception) {
             Terminal.log(Levels.ERROR, "Rose Writer has returned an exception : {}", exception.getMessage());

--- a/src/main/java/pw/mihou/rosedb/io/writers/RoseWriter.java
+++ b/src/main/java/pw/mihou/rosedb/io/writers/RoseWriter.java
@@ -1,5 +1,8 @@
 package pw.mihou.rosedb.io.writers;
 
+import journal.io.api.Journal;
+import journal.io.api.Location;
+import pw.mihou.rosedb.RoseDB;
 import pw.mihou.rosedb.enums.Levels;
 import pw.mihou.rosedb.io.FileHandler;
 import pw.mihou.rosedb.io.Scheduler;
@@ -19,53 +22,67 @@ public class RoseWriter {
     public static final ConcurrentLinkedQueue<RoseRequest> queue = new ConcurrentLinkedQueue<>();
     private static final AtomicBoolean activeThread = new AtomicBoolean(false);
 
-    public static void writeGZIP(String path, String value){
-        write(path, value, true, 0);
+    public static void writeGZIP(String path, String value) {
+        write(path, value, true);
     }
 
-    public static void write(String path, String value){
-        write(path, value, false, 0);
+    public static void write(String path, String value) {
+        write(path, value, false).join();
     }
 
-    public static void write(String database, String collection, String identifier, String json){
+    public static void write(String database, String collection, String identifier, String json) {
         Terminal.log(Levels.DEBUG, "Added to write queue: {}/{}/{}.rose with value {}", database, collection, identifier, json);
         queue.add(new RoseRequest(database, collection, identifier, json));
     }
 
-    public static synchronized void write(){
-        if(activeThread.get())
+    public static synchronized void write() {
+        if (activeThread.get())
             return;
 
         activeThread.set(true);
-        while(!queue.isEmpty()){
-            RoseRequest request = queue.poll();
-            Terminal.log(Levels.DEBUG, "Attempting to write on {}/{}/{}.rose with value {}", request.database, request.collection, request.identifier, request.json);
-            write(FileHandler.format(request.database, request.collection, request.identifier), request.json, true, 0);
+        try {
+            for (Location location : RoseDB.journal.redo()) {
+                RoseRequest request = RoseDB.gson.fromJson(new String(RoseDB.journal.read(location, Journal.ReadType.SYNC)), RoseRequest.class);
+                Terminal.log(Levels.DEBUG, "Request to write on {}/{}/{}.rose with value {} sent to writer.", request.database, request.collection,
+                        request.identifier, request.json);
+                RoseDB.journal.delete(location);
+                write(FileHandler.format(request.database, request.collection, request.identifier), request.json, true).join();
+            }
+            RoseDB.journal.sync();
+            RoseDB.journal.compact();
+
+            // We can also add the queue writer since collection adds are now done via journal.
+            while (!queue.isEmpty()) {
+                RoseRequest request = queue.poll();
+                Terminal.log(Levels.DEBUG, "Request to write on {}/{}/{}.rose with value {} sent to writer.", request.database, request.collection,
+                        request.identifier, request.json);
+                if (queue.peek() != null && request.compare(queue.peek()))
+                    write(FileHandler.format(request.database, request.collection, request.identifier), request.json, true).join();
+                else
+                    write(FileHandler.format(request.database, request.collection, request.identifier), request.json, true);
+            }
+        } catch (IOException exception) {
+            Terminal.log(Levels.ERROR, "Rose Writer has returned an exception : {}", exception.getMessage());
         }
         activeThread.set(false);
     }
 
-    private static synchronized CompletableFuture<Void> write(String path, String value, boolean gzip, int fails){
+    private static synchronized CompletableFuture<Void> write(String path, String value, boolean gzip) {
         return CompletableFuture.runAsync(() -> {
             FileHandler.mkdirs(path);
-
             try {
                 try (BufferedWriter writer = (!gzip ? Files.newBufferedWriter(new File(path).toPath()) :
-                        new BufferedWriter(new OutputStreamWriter(new GZIPOutputStream(( new FileOutputStream((new File(path)))), 65536))))) {
+                        new BufferedWriter(new OutputStreamWriter(new GZIPOutputStream((new FileOutputStream((new File(path)))), 8192))))) {
                     InternalLocks.lock(path);
+                    Terminal.log(Levels.DEBUG, "Attempting to write on {} with {} value.", path, value);
                     writer.write(value);
                 } catch (InternalLocks.FileLockedException e) {
-                    if(fails < 50) {
-                        Terminal.log(Levels.DEBUG, "Lock for {} was already acquired by JVM, thread will retry in awhile.", path);
-                        Thread.sleep(50);
-                        write(path, value, gzip, fails + 1);
-                    } else {
-                        Terminal.log(Levels.ERROR, "Unable to retrieve lock for {} after interval time: {}", path, e.getMessage());
-                    }
+                    Terminal.log(Levels.DEBUG, "Lock for {} was already acquired by JVM, thread will retry in awhile.", path);
+                    RoseDB.retry.executeRunnable(() -> write(path, value, gzip));
                 } finally {
                     InternalLocks.release(path);
                 }
-            } catch (IOException | InterruptedException e){
+            } catch (IOException e) {
                 Terminal.log(Levels.ERROR, "An error occurred while trying to write {}: {}", path, e.getMessage());
             }
         }, Scheduler.getExecutorService());

--- a/src/main/java/pw/mihou/rosedb/io/writers/RoseWriter.java
+++ b/src/main/java/pw/mihou/rosedb/io/writers/RoseWriter.java
@@ -1,0 +1,74 @@
+package pw.mihou.rosedb.io.writers;
+
+import pw.mihou.rosedb.enums.Levels;
+import pw.mihou.rosedb.io.FileHandler;
+import pw.mihou.rosedb.io.Scheduler;
+import pw.mihou.rosedb.io.entities.RoseRequest;
+import pw.mihou.rosedb.io.internals.InternalLocks;
+import pw.mihou.rosedb.utility.Terminal;
+
+import java.io.*;
+import java.nio.file.Files;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.zip.GZIPOutputStream;
+
+public class RoseWriter {
+
+    public static final ConcurrentLinkedQueue<RoseRequest> queue = new ConcurrentLinkedQueue<>();
+    private static final AtomicBoolean activeThread = new AtomicBoolean(false);
+
+    public static void writeGZIP(String path, String value){
+        write(path, value, true, 0);
+    }
+
+    public static void write(String path, String value){
+        write(path, value, false, 0);
+    }
+
+    public static void write(String database, String collection, String identifier, String json){
+        Terminal.log(Levels.DEBUG, "Added to write queue: {}/{}/{}.rose with value {}", database, collection, identifier, json);
+        queue.add(new RoseRequest(database, collection, identifier, json));
+    }
+
+    public static synchronized void write(){
+        if(activeThread.get())
+            return;
+
+        activeThread.set(true);
+        while(!queue.isEmpty()){
+            RoseRequest request = queue.poll();
+            Terminal.log(Levels.DEBUG, "Attempting to write on {}/{}/{}.rose with value {}", request.database, request.collection, request.identifier, request.json);
+            write(FileHandler.format(request.database, request.collection, request.identifier), request.json, true, 0);
+        }
+        activeThread.set(false);
+    }
+
+    private static synchronized CompletableFuture<Void> write(String path, String value, boolean gzip, int fails){
+        return CompletableFuture.runAsync(() -> {
+            FileHandler.mkdirs(path);
+
+            try {
+                try (BufferedWriter writer = (!gzip ? Files.newBufferedWriter(new File(path).toPath()) :
+                        new BufferedWriter(new OutputStreamWriter(new GZIPOutputStream(( new FileOutputStream((new File(path)))), 65536))))) {
+                    InternalLocks.lock(path);
+                    writer.write(value);
+                } catch (InternalLocks.FileLockedException e) {
+                    if(fails < 50) {
+                        Terminal.log(Levels.DEBUG, "Lock for {} was already acquired by JVM, thread will retry in awhile.", path);
+                        Thread.sleep(50);
+                        write(path, value, gzip, fails + 1);
+                    } else {
+                        Terminal.log(Levels.ERROR, "Unable to retrieve lock for {} after interval time: {}", path, e.getMessage());
+                    }
+                } finally {
+                    InternalLocks.release(path);
+                }
+            } catch (IOException | InterruptedException e){
+                Terminal.log(Levels.ERROR, "An error occurred while trying to write {}: {}", path, e.getMessage());
+            }
+        }, Scheduler.getExecutorService());
+    }
+
+}

--- a/src/main/java/pw/mihou/rosedb/listeners/AddListener.java
+++ b/src/main/java/pw/mihou/rosedb/listeners/AddListener.java
@@ -1,6 +1,6 @@
 package pw.mihou.rosedb.listeners;
 
-import io.javalin.websocket.WsContext;
+import org.java_websocket.WebSocket;
 import org.json.JSONException;
 import org.json.JSONObject;
 import pw.mihou.rosedb.connections.RoseServer;
@@ -8,6 +8,7 @@ import pw.mihou.rosedb.enums.Levels;
 import pw.mihou.rosedb.enums.Listening;
 import pw.mihou.rosedb.io.entities.QueryRequest;
 import pw.mihou.rosedb.manager.RoseCollections;
+import pw.mihou.rosedb.manager.RoseDatabase;
 import pw.mihou.rosedb.manager.entities.RoseListener;
 import pw.mihou.rosedb.utility.Terminal;
 
@@ -18,7 +19,7 @@ public class AddListener implements RoseListener {
     }
 
     @Override
-    public void execute(QueryRequest request, WsContext context, String unique) {
+    public void execute(QueryRequest request, WebSocket context, String unique) {
         try {
             execute(request.asJSONObject(), context, unique);
         } catch (JSONException e){
@@ -27,13 +28,13 @@ public class AddListener implements RoseListener {
     }
 
     @Override
-    public void execute(JSONObject request, WsContext context, String unique) {
+    public void execute(JSONObject request, WebSocket context, String unique) {
         if (request.isNull("value") || request.isNull("identifier")
                 || request.isNull("database") || request.isNull("collection")) {
             RoseServer.reply(context, "Missing parameters either: [value], [identifier], [database], [collection]", unique, -1);
         } else {
             Terminal.log(Levels.DEBUG, "Request to add {} with value {}", request.getString("identifier"), request.getString("value"));
-            RoseCollections collections = RoseServer.getDatabase(request.getString("database")).getCollection(request.getString("collection"));
+            RoseCollections collections = RoseDatabase.getDatabase(request.getString("database")).getCollection(request.getString("collection"));
             RoseServer.reply(context, collections.add(request.getString("identifier"), request.getString("value")), unique, 1);
         }
     }

--- a/src/main/java/pw/mihou/rosedb/listeners/AddListener.java
+++ b/src/main/java/pw/mihou/rosedb/listeners/AddListener.java
@@ -10,6 +10,7 @@ import pw.mihou.rosedb.io.entities.QueryRequest;
 import pw.mihou.rosedb.manager.RoseCollections;
 import pw.mihou.rosedb.manager.RoseDatabase;
 import pw.mihou.rosedb.manager.entities.RoseListener;
+import pw.mihou.rosedb.utility.Pair;
 import pw.mihou.rosedb.utility.Terminal;
 
 public class AddListener implements RoseListener {
@@ -35,7 +36,8 @@ public class AddListener implements RoseListener {
         } else {
             Terminal.log(Levels.DEBUG, "Request to add {} with value {}", request.getString("identifier"), request.getString("value"));
             RoseCollections collections = RoseDatabase.getDatabase(request.getString("database")).getCollection(request.getString("collection"));
-            RoseServer.reply(context, collections.add(request.getString("identifier"), request.getString("value")), unique, 1);
+            Pair<Integer, String> response = collections.add(request.getString("identifier"), request.getString("value"));
+            RoseServer.reply(context, response.getRight(), unique, response.getLeft());
         }
     }
 }

--- a/src/main/java/pw/mihou/rosedb/listeners/AddListener.java
+++ b/src/main/java/pw/mihou/rosedb/listeners/AddListener.java
@@ -1,10 +1,12 @@
 package pw.mihou.rosedb.listeners;
 
 import io.javalin.websocket.WsContext;
+import org.json.JSONException;
 import org.json.JSONObject;
 import pw.mihou.rosedb.connections.RoseServer;
 import pw.mihou.rosedb.enums.Levels;
 import pw.mihou.rosedb.enums.Listening;
+import pw.mihou.rosedb.io.entities.QueryRequest;
 import pw.mihou.rosedb.manager.RoseCollections;
 import pw.mihou.rosedb.manager.entities.RoseListener;
 import pw.mihou.rosedb.utility.Terminal;
@@ -13,6 +15,15 @@ public class AddListener implements RoseListener {
     @Override
     public Listening type() {
         return Listening.ADD;
+    }
+
+    @Override
+    public void execute(QueryRequest request, WsContext context, String unique) {
+        try {
+            execute(request.asJSONObject(), context, unique);
+        } catch (JSONException e){
+            RoseServer.reply(context, "The request was considered as invalid: " + e.getMessage(), unique, -1);
+        }
     }
 
     @Override

--- a/src/main/java/pw/mihou/rosedb/listeners/AggregateListener.java
+++ b/src/main/java/pw/mihou/rosedb/listeners/AggregateListener.java
@@ -4,6 +4,9 @@ import io.javalin.websocket.WsContext;
 import org.json.JSONObject;
 import pw.mihou.rosedb.connections.RoseServer;
 import pw.mihou.rosedb.enums.Listening;
+import pw.mihou.rosedb.io.RoseQuery;
+import pw.mihou.rosedb.io.entities.QueryRequest;
+import pw.mihou.rosedb.io.entities.RoseRequest;
 import pw.mihou.rosedb.manager.RoseCollections;
 import pw.mihou.rosedb.manager.entities.RoseListener;
 
@@ -16,15 +19,29 @@ public class AggregateListener implements RoseListener {
     }
 
     @Override
+    public void execute(QueryRequest request, WsContext context, String unique) {
+        handle(request, context, unique);
+    }
+
+    @Override
     public void execute(JSONObject request, WsContext context, String unique) {
-        if(request.isNull("collection") && !request.isNull("database")){
-            RoseServer.reply(context, new JSONObject().put(request.getString("database"), RoseServer.getDatabase(request.getString("database")).getCollections()
-                    .stream().collect(Collectors.toMap(collections -> collections.collection, RoseCollections::getData))),
-                    unique, 1);
-        } else if(!request.isNull("collection") && !request.isNull("database")){
-            RoseServer.reply(context, new JSONObject().put(request.getString("collection"),
-                    RoseServer.getDatabase(request.getString("database")).getCollection(request.getString("collection")).getData()),
-                    unique, 1);
+        handle(RoseQuery.parse(request), context, unique);
+    }
+
+    private void handle(QueryRequest request, WsContext context, String unique){
+        if(request.database == null && request.collection == null || request.database == null && request.collection != null){
+            RoseServer.reply(context, "Missing parameters either: [database], [collection]", unique, -1);
+        } else {
+            if(request.collection == null){
+                RoseServer.reply(context, new JSONObject().put(request.database,
+                        RoseServer.getDatabase(request.database).getCollections().stream()
+                                .collect(Collectors.toMap(collections -> collections.collection,
+                                        RoseCollections::getData))), unique, 1);
+            } else {
+                RoseServer.reply(context, new JSONObject().put(request.collection,
+                        RoseServer.getDatabase(request.database).getCollection(request.collection).getData()),
+                        unique, 1);
+            }
         }
     }
 }

--- a/src/main/java/pw/mihou/rosedb/listeners/AggregateListener.java
+++ b/src/main/java/pw/mihou/rosedb/listeners/AggregateListener.java
@@ -10,7 +10,6 @@ import pw.mihou.rosedb.io.entities.QueryRequest;
 import pw.mihou.rosedb.manager.RoseCollections;
 import pw.mihou.rosedb.manager.RoseDatabase;
 import pw.mihou.rosedb.manager.entities.RoseListener;
-import pw.mihou.rosedb.utility.Terminal;
 
 import java.util.stream.Collectors;
 

--- a/src/main/java/pw/mihou/rosedb/listeners/AggregateListener.java
+++ b/src/main/java/pw/mihou/rosedb/listeners/AggregateListener.java
@@ -1,14 +1,16 @@
 package pw.mihou.rosedb.listeners;
 
-import io.javalin.websocket.WsContext;
+import org.java_websocket.WebSocket;
 import org.json.JSONObject;
 import pw.mihou.rosedb.connections.RoseServer;
+import pw.mihou.rosedb.enums.Levels;
 import pw.mihou.rosedb.enums.Listening;
 import pw.mihou.rosedb.io.RoseQuery;
 import pw.mihou.rosedb.io.entities.QueryRequest;
-import pw.mihou.rosedb.io.entities.RoseRequest;
 import pw.mihou.rosedb.manager.RoseCollections;
+import pw.mihou.rosedb.manager.RoseDatabase;
 import pw.mihou.rosedb.manager.entities.RoseListener;
+import pw.mihou.rosedb.utility.Terminal;
 
 import java.util.stream.Collectors;
 
@@ -19,27 +21,27 @@ public class AggregateListener implements RoseListener {
     }
 
     @Override
-    public void execute(QueryRequest request, WsContext context, String unique) {
+    public void execute(QueryRequest request, WebSocket context, String unique) {
         handle(request, context, unique);
     }
 
     @Override
-    public void execute(JSONObject request, WsContext context, String unique) {
+    public void execute(JSONObject request, WebSocket context, String unique) {
         handle(RoseQuery.parse(request), context, unique);
     }
 
-    private void handle(QueryRequest request, WsContext context, String unique){
+    private void handle(QueryRequest request, WebSocket context, String unique){
         if(request.database == null && request.collection == null || request.database == null && request.collection != null){
             RoseServer.reply(context, "Missing parameters either: [database], [collection]", unique, -1);
         } else {
             if(request.collection == null){
                 RoseServer.reply(context, new JSONObject().put(request.database,
-                        RoseServer.getDatabase(request.database).getCollections().stream()
+                        RoseDatabase.getDatabase(request.database).getCollections().stream()
                                 .collect(Collectors.toMap(collections -> collections.collection,
                                         RoseCollections::getData))), unique, 1);
             } else {
                 RoseServer.reply(context, new JSONObject().put(request.collection,
-                        RoseServer.getDatabase(request.database).getCollection(request.collection).getData()),
+                        RoseDatabase.getDatabase(request.database).getCollection(request.collection).getData()),
                         unique, 1);
             }
         }

--- a/src/main/java/pw/mihou/rosedb/listeners/DeleteListener.java
+++ b/src/main/java/pw/mihou/rosedb/listeners/DeleteListener.java
@@ -13,6 +13,7 @@ import pw.mihou.rosedb.io.entities.QueryRequest;
 import pw.mihou.rosedb.manager.RoseCollections;
 import pw.mihou.rosedb.manager.RoseDatabase;
 import pw.mihou.rosedb.manager.entities.RoseListener;
+import pw.mihou.rosedb.utility.Pair;
 import pw.mihou.rosedb.utility.Terminal;
 
 public class DeleteListener implements RoseListener {
@@ -42,8 +43,11 @@ public class DeleteListener implements RoseListener {
             RoseServer.reply(context, "Missing parameters either: [key], [identifier], [database], [collection]", unique, -1);
         } else {
             if(keys == null){
-                RoseDatabase.getDatabase(request.database).getCollection(request.collection).delete(request.identifier);
-                RoseServer.reply(context, "The item: " + request.identifier + " was deleted.", unique, 1);
+                Pair<Boolean, String> val = RoseDatabase.getDatabase(request.database).getCollection(request.collection).delete(request.identifier);
+                if(val.getLeft())
+                    RoseServer.reply(context, "The item: " + request.identifier + " was deleted.", unique, 1);
+                else
+                    RoseServer.reply(context, "The item: " + request.identifier + " failed to delete: " + val.getRight(), unique, 0);
             } else {
                 RoseCollections collections = RoseDatabase.getDatabase(request.database).getCollection(request.collection);
                 collections.get(request.identifier).ifPresentOrElse(s -> {
@@ -59,8 +63,8 @@ public class DeleteListener implements RoseListener {
                             object.remove((String) keys);
                         }
 
-                        collections.add(request.identifier, object.toString());
-                        RoseServer.reply(context, object.toString(), unique, 1);
+                        Pair<Integer, String> response = collections.add(request.identifier, object.toString());
+                        RoseServer.reply(context, response.getRight(), unique, response.getLeft());
                     } catch (JSONException e) {
                         RoseServer.reply(context, request.identifier + " was reported as invalid JSON, did you perhaps change it manually: " + e.getMessage(), unique, -1);
                     }

--- a/src/main/java/pw/mihou/rosedb/listeners/DeleteListener.java
+++ b/src/main/java/pw/mihou/rosedb/listeners/DeleteListener.java
@@ -50,6 +50,9 @@ public class DeleteListener implements RoseListener {
                         } else if(keys instanceof String){
                             object.remove((String) keys);
                         }
+
+                        collections.add(request.identifier, object.toString());
+                        RoseServer.reply(context, object.toString(), unique, 1);
                     } catch (JSONException e) {
                         RoseServer.reply(context, request.identifier + " was reported as invalid JSON, did you perhaps change it manually: " + e.getMessage(), unique, -1);
                     }

--- a/src/main/java/pw/mihou/rosedb/listeners/DeleteListener.java
+++ b/src/main/java/pw/mihou/rosedb/listeners/DeleteListener.java
@@ -1,11 +1,14 @@
 package pw.mihou.rosedb.listeners;
 
 import io.javalin.websocket.WsContext;
+import org.jetbrains.annotations.Nullable;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import pw.mihou.rosedb.connections.RoseServer;
 import pw.mihou.rosedb.enums.Listening;
+import pw.mihou.rosedb.io.RoseQuery;
+import pw.mihou.rosedb.io.entities.QueryRequest;
 import pw.mihou.rosedb.manager.RoseCollections;
 import pw.mihou.rosedb.manager.entities.RoseListener;
 
@@ -16,37 +19,41 @@ public class DeleteListener implements RoseListener {
     }
 
     @Override
+    public void execute(QueryRequest request, WsContext context, String unique) {
+        JSONObject val = request.valueAsJSONObject();
+        handle(request, val.isNull("key") ? null : val.get("val"), context, unique);
+    }
+
+    @Override
     public void execute(JSONObject request, WsContext context, String unique) {
-        if (request.isNull("identifier") || request.isNull("database") || request.isNull("collection")) {
+        handle(RoseQuery.parse(request), request.isNull("key") ? null : request.get("key"), context, unique);
+    }
+
+    private void handle(QueryRequest request, @Nullable Object keys, WsContext context, String unique){
+        if(request.identifier == null || request.database == null || request.collection == null){
             RoseServer.reply(context, "Missing parameters either: [key], [identifier], [database], [collection]", unique, -1);
         } else {
-            if (request.isNull("key")) {
-                RoseServer.getDatabase(request.getString("database")).getCollection(request.getString("collection"))
-                        .delete(request.getString("identifier"));
-                RoseServer.reply(context, "The item: " + request.getString("identifier") + " was deleted.", unique, 1);
-            } else if (!request.isNull("key")) {
-                RoseCollections collections = RoseServer.getDatabase(request.getString("database")).getCollection(request.getString("collection"));
-                collections.get(request.getString("identifier")).ifPresentOrElse(roseEntity -> {
+            if(keys == null){
+                RoseServer.getDatabase(request.database).getCollection(request.collection).delete(request.identifier);
+                RoseServer.reply(context, "The item: " + request.identifier + " was deleted.", unique, 1);
+            } else {
+                RoseCollections collections = RoseServer.getDatabase(request.database).getCollection(request.collection);
+                collections.get(request.identifier).ifPresentOrElse(s -> {
                     try {
-                        JSONObject object = new JSONObject(roseEntity);
-                        if (request.get("key") instanceof JSONArray) {
-                            JSONArray key = request.getJSONArray("key");
+                        JSONObject object = new JSONObject(s);
+                        if(keys instanceof JSONArray){
+                            JSONArray key = (JSONArray) keys;
 
-                            for (int i = 0; i < key.length(); i++) {
+                            for(int i = 0; i < key.length(); i++){
                                 object.remove(key.getString(i));
                             }
-                        } else {
-                            object.remove(request.getString("key"));
+                        } else if(keys instanceof String){
+                            object.remove((String) keys);
                         }
-
-                        collections.add(request.getString("identifier"), object.toString());
-                        RoseServer.reply(context, object.toString(), unique, 1);
                     } catch (JSONException e) {
-                        RoseServer.reply(context, request.getString("identifier") + " reported as invalid JSON, did you perhaps change it manually: " + e.getMessage(), unique, -1);
+                        RoseServer.reply(context, request.identifier + " was reported as invalid JSON, did you perhaps change it manually: " + e.getMessage(), unique, -1);
                     }
-                }, () -> RoseServer.reply(context, "No results for identifier: " + request.getString("identifier"), unique, -1));
-            } else {
-                RoseServer.reply(context, "Missing parameters either: [key], [identifier], [database], [collection]", unique, -1);
+                }, () -> RoseServer.reply(context, "No results for identifier: " + request.identifier, unique, 0));
             }
         }
     }

--- a/src/main/java/pw/mihou/rosedb/listeners/DropListener.java
+++ b/src/main/java/pw/mihou/rosedb/listeners/DropListener.java
@@ -8,6 +8,7 @@ import pw.mihou.rosedb.io.RoseQuery;
 import pw.mihou.rosedb.io.entities.QueryRequest;
 import pw.mihou.rosedb.manager.RoseDatabase;
 import pw.mihou.rosedb.manager.entities.RoseListener;
+import pw.mihou.rosedb.utility.Pair;
 
 public class DropListener implements RoseListener {
     @Override
@@ -31,11 +32,17 @@ public class DropListener implements RoseListener {
             RoseServer.reply(context, "Missing parameters either: [database], [collection]", unique, -1);
         } else {
             if(request.collection == null){
-                RoseDatabase.removeDatabase(request.database);
-                RoseServer.reply(context, "Successfully deleted the database " + request.database, unique, 1);
+                Pair<Boolean, String> val = RoseDatabase.removeDatabase(request.database);
+                if(val.getLeft())
+                    RoseServer.reply(context, "Successfully deleted the database " + request.database, unique, 1);
+                else
+                    RoseServer.reply(context, "Failed to delete the database " + request.database + ": " + val.getRight(), unique, 1);
             } else {
-                RoseDatabase.getDatabase(request.database).removeCollection(request.collection);
-                RoseServer.reply(context, "Successfully deleted the collection " + request.collection, unique, 1);
+                Pair<Boolean, String> val = RoseDatabase.getDatabase(request.database).removeCollection(request.collection);
+                if(val.getLeft())
+                    RoseServer.reply(context, "Successfully deleted the collection " + request.collection, unique, 1);
+                else
+                    RoseServer.reply(context, "Failed to delete the collection " + request.collection + ": " + val.getRight(), unique, 1);
             }
         }
     }

--- a/src/main/java/pw/mihou/rosedb/listeners/DropListener.java
+++ b/src/main/java/pw/mihou/rosedb/listeners/DropListener.java
@@ -1,15 +1,13 @@
 package pw.mihou.rosedb.listeners;
 
-import io.javalin.websocket.WsContext;
+import org.java_websocket.WebSocket;
 import org.json.JSONObject;
-import pw.mihou.rosedb.RoseDB;
 import pw.mihou.rosedb.connections.RoseServer;
 import pw.mihou.rosedb.enums.Listening;
 import pw.mihou.rosedb.io.RoseQuery;
 import pw.mihou.rosedb.io.entities.QueryRequest;
+import pw.mihou.rosedb.manager.RoseDatabase;
 import pw.mihou.rosedb.manager.entities.RoseListener;
-
-import java.io.IOException;
 
 public class DropListener implements RoseListener {
     @Override
@@ -18,30 +16,26 @@ public class DropListener implements RoseListener {
     }
 
     @Override
-    public void execute(QueryRequest request, WsContext context, String unique) {
+    public void execute(QueryRequest request, WebSocket context, String unique) {
         handle(request, context, unique);
     }
 
     @Override
-    public void execute(JSONObject request, WsContext context, String unique) {
+    public void execute(JSONObject request, WebSocket context, String unique) {
         handle(RoseQuery.parse(request), context, unique);
     }
 
     @SuppressWarnings("ConstantConditions")
-    private void handle(QueryRequest request, WsContext context, String unique){
+    private void handle(QueryRequest request, WebSocket context, String unique){
         if(request.database == null && request.collection == null || request.database == null && request.collection != null){
             RoseServer.reply(context, "Missing parameters either: [database], [collection]", unique, -1);
         } else {
-            try {
-                if(request.collection == null){
-                    RoseServer.removeDatabase(request.database);
-                    RoseServer.reply(context, "Successfully deleted the database " + request.database, unique, 1);
-                } else {
-                    RoseServer.getDatabase(request.database).removeCollection(request.collection);
-                    RoseServer.reply(context, "Successfully deleted the collection " + request.collection, unique, 1);
-                }
-            } catch (IOException exception){
-                RoseServer.reply(context, "An exception occurred: " + exception.getMessage(), unique, -1);
+            if(request.collection == null){
+                RoseDatabase.removeDatabase(request.database);
+                RoseServer.reply(context, "Successfully deleted the database " + request.database, unique, 1);
+            } else {
+                RoseDatabase.getDatabase(request.database).removeCollection(request.collection);
+                RoseServer.reply(context, "Successfully deleted the collection " + request.collection, unique, 1);
             }
         }
     }

--- a/src/main/java/pw/mihou/rosedb/listeners/DropListener.java
+++ b/src/main/java/pw/mihou/rosedb/listeners/DropListener.java
@@ -2,8 +2,11 @@ package pw.mihou.rosedb.listeners;
 
 import io.javalin.websocket.WsContext;
 import org.json.JSONObject;
+import pw.mihou.rosedb.RoseDB;
 import pw.mihou.rosedb.connections.RoseServer;
 import pw.mihou.rosedb.enums.Listening;
+import pw.mihou.rosedb.io.RoseQuery;
+import pw.mihou.rosedb.io.entities.QueryRequest;
 import pw.mihou.rosedb.manager.entities.RoseListener;
 
 import java.io.IOException;
@@ -15,19 +18,29 @@ public class DropListener implements RoseListener {
     }
 
     @Override
+    public void execute(QueryRequest request, WsContext context, String unique) {
+        handle(request, context, unique);
+    }
+
+    @Override
     public void execute(JSONObject request, WsContext context, String unique) {
-        if (request.isNull("database") && request.isNull("collection") || request.isNull("database") && !request.isNull("collection")) {
+        handle(RoseQuery.parse(request), context, unique);
+    }
+
+    @SuppressWarnings("ConstantConditions")
+    private void handle(QueryRequest request, WsContext context, String unique){
+        if(request.database == null && request.collection == null || request.database == null && request.collection != null){
             RoseServer.reply(context, "Missing parameters either: [database], [collection]", unique, -1);
         } else {
             try {
-                if (request.isNull("collection")) {
-                    RoseServer.removeDatabase(request.getString("database"));
-                    RoseServer.reply(context, "Successfully deleted the database " + request.getString("database"), unique, 1);
+                if(request.collection == null){
+                    RoseServer.removeDatabase(request.database);
+                    RoseServer.reply(context, "Successfully deleted the database " + request.database, unique, 1);
                 } else {
-                    RoseServer.getDatabase(request.getString("database")).removeCollection(request.getString("collection"));
-                    RoseServer.reply(context, "Successfully deleted the collection " + request.getString("collection"), unique, 1);
+                    RoseServer.getDatabase(request.database).removeCollection(request.collection);
+                    RoseServer.reply(context, "Successfully deleted the collection " + request.collection, unique, 1);
                 }
-            } catch (IOException exception) {
+            } catch (IOException exception){
                 RoseServer.reply(context, "An exception occurred: " + exception.getMessage(), unique, -1);
             }
         }

--- a/src/main/java/pw/mihou/rosedb/listeners/RequestListener.java
+++ b/src/main/java/pw/mihou/rosedb/listeners/RequestListener.java
@@ -4,6 +4,8 @@ import io.javalin.websocket.WsContext;
 import org.json.JSONObject;
 import pw.mihou.rosedb.connections.RoseServer;
 import pw.mihou.rosedb.enums.Listening;
+import pw.mihou.rosedb.io.RoseQuery;
+import pw.mihou.rosedb.io.entities.QueryRequest;
 import pw.mihou.rosedb.manager.entities.RoseListener;
 
 public class RequestListener implements RoseListener {
@@ -14,13 +16,21 @@ public class RequestListener implements RoseListener {
     }
 
     @Override
+    public void execute(QueryRequest request, WsContext context, String unique) {
+        handle(request, context, unique);
+    }
+
+    @Override
     public void execute(JSONObject request, WsContext context, String unique) {
-        if (request.isNull("identifier") || request.isNull("database") || request.isNull("collection")) {
+        handle(RoseQuery.parse(request), context, unique);
+    }
+
+    private void handle(QueryRequest request, WsContext context, String unique){
+        if(request.identifier == null || request.database == null || request.collection == null)
             RoseServer.reply(context, "Missing parameters either: [identifier], [database], [collection]", unique, -1);
-        } else {
-            RoseServer.getDatabase(request.getString("database")).getCollection(request.getString("collection"))
-                    .get(request.getString("identifier")).ifPresentOrElse(roseEntity -> RoseServer.reply(context, roseEntity, unique, 1),
-                    () -> RoseServer.reply(context, "No results.", unique, 0));
-        }
+        else
+            RoseServer.getDatabase(request.database).getCollection(request.collection)
+            .get(request.identifier).ifPresentOrElse(s -> RoseServer.reply(context, s, unique, 1), () ->
+                    RoseServer.reply(context, "No results for " + request.identifier, unique, 0));
     }
 }

--- a/src/main/java/pw/mihou/rosedb/listeners/RequestListener.java
+++ b/src/main/java/pw/mihou/rosedb/listeners/RequestListener.java
@@ -1,11 +1,12 @@
 package pw.mihou.rosedb.listeners;
 
-import io.javalin.websocket.WsContext;
+import org.java_websocket.WebSocket;
 import org.json.JSONObject;
 import pw.mihou.rosedb.connections.RoseServer;
 import pw.mihou.rosedb.enums.Listening;
 import pw.mihou.rosedb.io.RoseQuery;
 import pw.mihou.rosedb.io.entities.QueryRequest;
+import pw.mihou.rosedb.manager.RoseDatabase;
 import pw.mihou.rosedb.manager.entities.RoseListener;
 
 public class RequestListener implements RoseListener {
@@ -16,20 +17,20 @@ public class RequestListener implements RoseListener {
     }
 
     @Override
-    public void execute(QueryRequest request, WsContext context, String unique) {
+    public void execute(QueryRequest request, WebSocket context, String unique) {
         handle(request, context, unique);
     }
 
     @Override
-    public void execute(JSONObject request, WsContext context, String unique) {
+    public void execute(JSONObject request, WebSocket context, String unique) {
         handle(RoseQuery.parse(request), context, unique);
     }
 
-    private void handle(QueryRequest request, WsContext context, String unique){
+    private void handle(QueryRequest request, WebSocket context, String unique){
         if(request.identifier == null || request.database == null || request.collection == null)
             RoseServer.reply(context, "Missing parameters either: [identifier], [database], [collection]", unique, -1);
         else
-            RoseServer.getDatabase(request.database).getCollection(request.collection)
+            RoseDatabase.getDatabase(request.database).getCollection(request.collection)
             .get(request.identifier).ifPresentOrElse(s -> RoseServer.reply(context, s, unique, 1), () ->
                     RoseServer.reply(context, "No results for " + request.identifier, unique, 0));
     }

--- a/src/main/java/pw/mihou/rosedb/listeners/RevertListener.java
+++ b/src/main/java/pw/mihou/rosedb/listeners/RevertListener.java
@@ -1,12 +1,13 @@
 package pw.mihou.rosedb.listeners;
 
-import io.javalin.websocket.WsContext;
+import org.java_websocket.WebSocket;
 import org.json.JSONObject;
 import pw.mihou.rosedb.RoseDB;
 import pw.mihou.rosedb.connections.RoseServer;
 import pw.mihou.rosedb.enums.Listening;
 import pw.mihou.rosedb.io.RoseQuery;
 import pw.mihou.rosedb.io.entities.QueryRequest;
+import pw.mihou.rosedb.manager.RoseDatabase;
 import pw.mihou.rosedb.manager.entities.RoseListener;
 import pw.mihou.rosedb.utility.Pair;
 
@@ -18,21 +19,21 @@ public class RevertListener implements RoseListener {
     }
 
     @Override
-    public void execute(QueryRequest request, WsContext context, String unique) {
+    public void execute(QueryRequest request, WebSocket context, String unique) {
         handle(request, context, unique);
     }
 
     @Override
-    public void execute(JSONObject request, WsContext context, String unique) {
+    public void execute(JSONObject request, WebSocket context, String unique) {
         handle(RoseQuery.parse(request), context, unique);
     }
 
-    private void handle(QueryRequest request, WsContext context, String unique){
+    private void handle(QueryRequest request, WebSocket context, String unique){
         if(RoseDB.versioning)
             if(request.identifier == null || request.database == null || request.collection == null){
                 RoseServer.reply(context, "Missing parameters either:  [identifier], [database], [collection]", unique, -1);
             } else {
-                Pair<Boolean, String> response = RoseServer.getDatabase(request.database)
+                Pair<Boolean, String> response = RoseDatabase.getDatabase(request.database)
                         .getCollection(request.collection).revert(request.identifier);
 
                 if(response.getLeft())

--- a/src/main/java/pw/mihou/rosedb/listeners/RevertListener.java
+++ b/src/main/java/pw/mihou/rosedb/listeners/RevertListener.java
@@ -5,6 +5,8 @@ import org.json.JSONObject;
 import pw.mihou.rosedb.RoseDB;
 import pw.mihou.rosedb.connections.RoseServer;
 import pw.mihou.rosedb.enums.Listening;
+import pw.mihou.rosedb.io.RoseQuery;
+import pw.mihou.rosedb.io.entities.QueryRequest;
 import pw.mihou.rosedb.manager.entities.RoseListener;
 import pw.mihou.rosedb.utility.Pair;
 
@@ -16,14 +18,22 @@ public class RevertListener implements RoseListener {
     }
 
     @Override
+    public void execute(QueryRequest request, WsContext context, String unique) {
+        handle(request, context, unique);
+    }
+
+    @Override
     public void execute(JSONObject request, WsContext context, String unique) {
+        handle(RoseQuery.parse(request), context, unique);
+    }
+
+    private void handle(QueryRequest request, WsContext context, String unique){
         if(RoseDB.versioning)
-            if (request.isNull("identifier") || request.isNull("database") || request.isNull("collection")) {
+            if(request.identifier == null || request.database == null || request.collection == null){
                 RoseServer.reply(context, "Missing parameters either:  [identifier], [database], [collection]", unique, -1);
             } else {
-                Pair<Boolean, String> response = RoseServer.getDatabase(request.getString("database"))
-                        .getCollection(request.getString("collection"))
-                        .revert(request.getString("identifier"));
+                Pair<Boolean, String> response = RoseServer.getDatabase(request.database)
+                        .getCollection(request.collection).revert(request.identifier);
 
                 if(response.getLeft())
                     RoseServer.reply(context, response.getRight(), unique, 1);
@@ -31,6 +41,6 @@ public class RevertListener implements RoseListener {
                     RoseServer.reply(context, "There are no backup versions for the requested item.", unique, 0);
             }
         else
-            RoseServer.reply(context, "This method is unsupported by the server.", unique, 0);
+            RoseServer.reply(context, "This method is not supported by the server.", unique, 0);
     }
 }

--- a/src/main/java/pw/mihou/rosedb/listeners/UpdateListener.java
+++ b/src/main/java/pw/mihou/rosedb/listeners/UpdateListener.java
@@ -1,11 +1,14 @@
 package pw.mihou.rosedb.listeners;
 
 import io.javalin.websocket.WsContext;
+import org.jetbrains.annotations.Nullable;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import pw.mihou.rosedb.connections.RoseServer;
 import pw.mihou.rosedb.enums.Listening;
+import pw.mihou.rosedb.io.RoseQuery;
+import pw.mihou.rosedb.io.entities.QueryRequest;
 import pw.mihou.rosedb.manager.RoseCollections;
 import pw.mihou.rosedb.manager.entities.RoseListener;
 
@@ -16,39 +19,50 @@ public class UpdateListener implements RoseListener {
     }
 
     @Override
+    public void execute(QueryRequest request, WsContext context, String unique) {
+        JSONObject val = request.valueAsJSONObject();
+        handle(request, val.isNull("key") ? null : val.get("key"), val.isNull("value") ? null : val.get("value"),
+                context, unique);
+    }
+
+    @Override
     public void execute(JSONObject request, WsContext context, String unique) {
-        if (request.isNull("identifier") || request.isNull("database") || request.isNull("collection")) {
+        handle(RoseQuery.parse(request), request.isNull("key") ? null : request.get("key"), request.isNull("value") ? null : request.get("value"),
+                context, unique);
+    }
+
+    private void handle(QueryRequest request, @Nullable Object key, @Nullable Object value, WsContext context, String unique){
+        if(request.identifier == null || request.database == null || request.collection == null){
             RoseServer.reply(context, "Missing parameters either: [value], [key], [identifier], [database], [collection]", unique, -1);
         } else {
-            if (request.isNull("key") && !request.isNull("value")) {
-                RoseServer.reply(context, RoseServer
-                        .getDatabase(request.getString("database"))
-                        .getCollection(request.getString("collection"))
-                        .add(request.getString("identifier"), request.getString("value")), unique, 1);
-            } else if (!request.isNull("key") && !request.isNull("value")) {
-                RoseCollections collections = RoseServer.getDatabase(request.getString("database")).getCollection(request.getString("collection"));
-                collections.get(request.getString("identifier")).ifPresentOrElse(roseEntity -> {
+            if(key == null && value != null){
+                RoseServer.reply(context, RoseServer.getDatabase(request.database)
+                .getCollection(request.collection).add(request.identifier, request.value), unique, 1);
+            } else if(key != null && value != null){
+                RoseCollections collections = RoseServer.getDatabase(request.database).getCollection(request.collection);
+                collections.get(request.identifier).ifPresentOrElse(s -> {
                     try {
-                        JSONObject object = new JSONObject(roseEntity);
-                        if (request.get("key") instanceof JSONArray && request.get("value") instanceof JSONArray) {
-                            JSONArray key = request.getJSONArray("key");
-                            JSONArray value = request.getJSONArray("value");
+                        JSONObject object = new JSONObject(s);
+                        if(key instanceof JSONArray && value instanceof JSONArray){
+                            JSONArray keys = (JSONArray) key;
+                            JSONArray values = (JSONArray) value;
 
-                            for (int i = 0; i < key.length(); i++) {
-                                object.put(key.getString(i), value.get(i));
+                            for(int i = 0; i < keys.length(); i++){
+                                object.put(keys.getString(i), values.get(i));
                             }
-                        } else {
-                            object.put(request.getString("key"), request.get("value"));
+                        } else if(key instanceof String){
+                            object.put((String) key, value);
                         }
 
-                        collections.add(request.getString("identifier"), object.toString());
+                        collections.add(request.identifier, object.toString());
                         RoseServer.reply(context, object.toString(), unique, 1);
-                    } catch (JSONException e) {
-                        RoseServer.reply(context, request.getString("identifier") + " reported as invalid JSON, did you perhaps change it manually: " + e.getMessage(), unique, -1);
+                    } catch (JSONException e){
+                        RoseServer.reply(context, request.identifier + " reported as invalid JSON, did you perhaps change it manually: " + e.getMessage(),
+                                unique, -1);
                     }
-                }, () -> RoseServer.reply(context, "No results for identifier: " + request.getString("identifier"), unique, -1));
+                }, () -> RoseServer.reply(context, "No results for identifier: " + request.identifier, unique, 0));
             } else {
-                RoseServer.reply(context, "Missing parameters either: [value], [key], [identifier], [database], [collection]", unique, -1);
+                RoseServer.reply(context, "Missing parameters: [key], [value] or [value]", unique, -1);
             }
         }
     }

--- a/src/main/java/pw/mihou/rosedb/listeners/UpdateListener.java
+++ b/src/main/java/pw/mihou/rosedb/listeners/UpdateListener.java
@@ -1,6 +1,6 @@
 package pw.mihou.rosedb.listeners;
 
-import io.javalin.websocket.WsContext;
+import org.java_websocket.WebSocket;
 import org.jetbrains.annotations.Nullable;
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -10,6 +10,7 @@ import pw.mihou.rosedb.enums.Listening;
 import pw.mihou.rosedb.io.RoseQuery;
 import pw.mihou.rosedb.io.entities.QueryRequest;
 import pw.mihou.rosedb.manager.RoseCollections;
+import pw.mihou.rosedb.manager.RoseDatabase;
 import pw.mihou.rosedb.manager.entities.RoseListener;
 
 public class UpdateListener implements RoseListener {
@@ -19,27 +20,27 @@ public class UpdateListener implements RoseListener {
     }
 
     @Override
-    public void execute(QueryRequest request, WsContext context, String unique) {
+    public void execute(QueryRequest request, WebSocket context, String unique) {
         JSONObject val = request.valueAsJSONObject();
         handle(request, val.isNull("key") ? null : val.get("key"), val.isNull("value") ? null : val.get("value"),
                 context, unique);
     }
 
     @Override
-    public void execute(JSONObject request, WsContext context, String unique) {
+    public void execute(JSONObject request, WebSocket context, String unique) {
         handle(RoseQuery.parse(request), request.isNull("key") ? null : request.get("key"), request.isNull("value") ? null : request.get("value"),
                 context, unique);
     }
 
-    private void handle(QueryRequest request, @Nullable Object key, @Nullable Object value, WsContext context, String unique){
+    private void handle(QueryRequest request, @Nullable Object key, @Nullable Object value, WebSocket context, String unique){
         if(request.identifier == null || request.database == null || request.collection == null){
             RoseServer.reply(context, "Missing parameters either: [value], [key], [identifier], [database], [collection]", unique, -1);
         } else {
             if(key == null && value != null){
-                RoseServer.reply(context, RoseServer.getDatabase(request.database)
+                RoseServer.reply(context, RoseDatabase.getDatabase(request.database)
                 .getCollection(request.collection).add(request.identifier, request.value), unique, 1);
             } else if(key != null && value != null){
-                RoseCollections collections = RoseServer.getDatabase(request.database).getCollection(request.collection);
+                RoseCollections collections = RoseDatabase.getDatabase(request.database).getCollection(request.collection);
                 collections.get(request.identifier).ifPresentOrElse(s -> {
                     try {
                         JSONObject object = new JSONObject(s);

--- a/src/main/java/pw/mihou/rosedb/listeners/UpdateListener.java
+++ b/src/main/java/pw/mihou/rosedb/listeners/UpdateListener.java
@@ -12,6 +12,7 @@ import pw.mihou.rosedb.io.entities.QueryRequest;
 import pw.mihou.rosedb.manager.RoseCollections;
 import pw.mihou.rosedb.manager.RoseDatabase;
 import pw.mihou.rosedb.manager.entities.RoseListener;
+import pw.mihou.rosedb.utility.Pair;
 
 public class UpdateListener implements RoseListener {
     @Override
@@ -37,8 +38,9 @@ public class UpdateListener implements RoseListener {
             RoseServer.reply(context, "Missing parameters either: [value], [key], [identifier], [database], [collection]", unique, -1);
         } else {
             if(key == null && value != null){
-                RoseServer.reply(context, RoseDatabase.getDatabase(request.database)
-                .getCollection(request.collection).add(request.identifier, request.value), unique, 1);
+                Pair<Integer, String> response =  RoseDatabase.getDatabase(request.database)
+                        .getCollection(request.collection).add(request.identifier, request.value);
+                RoseServer.reply(context, response.getRight(), unique, response.getLeft());
             } else if(key != null && value != null){
                 RoseCollections collections = RoseDatabase.getDatabase(request.database).getCollection(request.collection);
                 collections.get(request.identifier).ifPresentOrElse(s -> {
@@ -55,8 +57,8 @@ public class UpdateListener implements RoseListener {
                             object.put((String) key, value);
                         }
 
-                        collections.add(request.identifier, object.toString());
-                        RoseServer.reply(context, object.toString(), unique, 1);
+                        Pair<Integer, String> response = collections.add(request.identifier, object.toString());
+                        RoseServer.reply(context, response.getRight(), unique, response.getLeft());
                     } catch (JSONException e){
                         RoseServer.reply(context, request.identifier + " reported as invalid JSON, did you perhaps change it manually: " + e.getMessage(),
                                 unique, -1);

--- a/src/main/java/pw/mihou/rosedb/manager/RoseCollections.java
+++ b/src/main/java/pw/mihou/rosedb/manager/RoseCollections.java
@@ -1,15 +1,13 @@
 package pw.mihou.rosedb.manager;
 
-import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
 import pw.mihou.rosedb.RoseDB;
-import pw.mihou.rosedb.enums.Levels;
 import pw.mihou.rosedb.io.FileHandler;
 import pw.mihou.rosedb.io.Scheduler;
+import pw.mihou.rosedb.io.deleter.RoseDeleter;
+import pw.mihou.rosedb.io.writers.RoseWriter;
 import pw.mihou.rosedb.utility.Pair;
-import pw.mihou.rosedb.utility.Terminal;
-
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
@@ -21,6 +19,12 @@ public class RoseCollections {
     public final String collection;
     private final String database;
 
+    /**
+     * Creates a new collection on the database.
+     *
+     * @param collection The name of the collection.
+     * @param database The database where it is being held.
+     */
     public RoseCollections(String collection, String database) {
         this.collection = collection;
         this.database = database;
@@ -35,10 +39,22 @@ public class RoseCollections {
         }
     }
 
+    /**
+     * Caches an item to the memory.
+     *
+     * @param identifier The identifier of the item.
+     * @param json The item's value which should be in JSON.
+     */
     public void cache(String identifier, String json) {
         this.data.put(identifier, json);
     }
 
+    /**
+     * Reverts an item a step backwards before a recent change occurred.
+     *
+     * @param identifier The identifier of the item.
+     * @return The old value inside the item.
+     */
     public Pair<Boolean, String> revert(String identifier){
         if(versions.get(identifier) == null)
             return new Pair<>(false, "");
@@ -50,29 +66,57 @@ public class RoseCollections {
         return new Pair<>(true, json);
     }
 
+    /**
+     * Deletes an item from the collection.
+     *
+     * @param identifier The identifier of the item.
+     */
     public void delete(String identifier) {
         this.data.invalidate(identifier);
-        Scheduler.submit(() -> FileHandler.delete(database, collection, identifier));
+        Scheduler.submit(() -> RoseDeleter.delete(database, collection, identifier));
     }
 
+    /**
+     * Gets all the items inside the collection,
+     *
+     * @return All the items inside the collection.
+     */
     public Map<String, String> getData(){
         return data.asMap();
     }
 
+    /**
+     * Gets all the backup versions of the items inside the collection.
+     *
+     * @return All the backup versions of the items of the collection.
+     */
     public Map<String, String> getVersions(){
         return versions.asMap();
     }
 
+    /**
+     * Adds an item to the collection.
+     *
+     * @param identifier The identifier of the item.
+     * @param json The value of the item, should always be in JSON.
+     * @return The value of the item.
+     */
     public String add(String identifier, String json) {
         if(RoseDB.versioning && this.data.get(identifier) != null) {
             this.versions.put(identifier, this.data.get(identifier));
         }
 
         this.data.put(identifier, json);
-        FileHandler.write(database, collection, identifier, json);
+        RoseWriter.write(database, collection, identifier, json);
         return json;
     }
 
+    /**
+     * Gets an item from the collection if it exists.
+     *
+     * @param identifier The identifier of the item.
+     * @return The value of the item, if it exists.
+     */
     public Optional<String> get(String identifier) {
         return Optional.ofNullable(data.get(identifier));
     }

--- a/src/main/java/pw/mihou/rosedb/manager/RoseCollections.java
+++ b/src/main/java/pw/mihou/rosedb/manager/RoseCollections.java
@@ -79,9 +79,11 @@ public class RoseCollections {
      *
      * @param identifier The identifier of the item.
      */
-    public void delete(String identifier) {
-        this.data.invalidate(identifier);
-        Scheduler.submit(() -> RoseDeleter.delete(database, collection, identifier));
+    public Pair<Boolean, String> delete(String identifier) {
+        Pair<Boolean, String> val = RoseDeleter.delete(database, collection, identifier);
+        if(val.getLeft())
+            this.data.invalidate(identifier);
+        return val;
     }
 
     /**

--- a/src/main/java/pw/mihou/rosedb/manager/RoseDatabase.java
+++ b/src/main/java/pw/mihou/rosedb/manager/RoseDatabase.java
@@ -2,12 +2,13 @@ package pw.mihou.rosedb.manager;
 
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
-import org.apache.commons.io.FileUtils;
 import pw.mihou.rosedb.RoseDB;
 import pw.mihou.rosedb.io.FileHandler;
+import pw.mihou.rosedb.io.Scheduler;
+import pw.mihou.rosedb.io.deleter.RoseDeleter;
+import pw.mihou.rosedb.io.writers.RoseWriter;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.Collection;
 import java.util.stream.Collectors;
 
@@ -15,6 +16,8 @@ public class RoseDatabase {
 
     private final String database;
     private final LoadingCache<String, RoseCollections> rosy;
+    public static final LoadingCache<String, RoseDatabase> databases = Caffeine.newBuilder()
+            .build(key -> FileHandler.readDatabase(key.toLowerCase()).join());
 
     public RoseDatabase(String database) {
         this.database = database;
@@ -22,27 +25,75 @@ public class RoseDatabase {
                 .build(key -> FileHandler.readCollection(database, key).join());
     }
 
+    /**
+     * Places a collection inside the cache.
+     *
+     * @param collection The name of the collection.
+     * @param collections The actual Collections object.
+     */
     public void cache(String collection, RoseCollections collections) {
         this.rosy.put(collection, collections);
     }
 
+    /**
+     * Gets all the collections inside the database.
+     *
+     * @return All the collection inside the database.
+     */
     public Collection<RoseCollections> getCollections(){
         return rosy.asMap().values();
     }
 
+    /**
+     * Gets the collection if it exists, or else makes one.
+     *
+     * @param collection The collection name to get.
+     * @return The requested collection.
+     */
     public RoseCollections getCollection(String collection) {
         return rosy.get(collection);
     }
 
+    /**
+     * Gets the name of the database.
+     *
+     * @return The name of the database.
+     */
     public String getDatabase(){
         return database;
     }
 
-    public void removeCollection(String collection) throws IOException {
-        FileUtils.deleteDirectory(new File(RoseDB.directory + "/" + database + "/" + collection + "/"));
-        FileHandler.queue.removeAll(FileHandler.queue.stream().filter(r -> r.collection.equals(collection))
-                .collect(Collectors.toUnmodifiableList()));
+    /**
+     * Removes a collection inside the database.
+     *
+     * @param collection The name of the collection to remove.
+     */
+    public void removeCollection(String collection) {
         this.rosy.invalidate(collection);
+        RoseWriter.queue.removeAll(RoseWriter.queue.stream().filter(r -> r.collection.equals(collection))
+                .collect(Collectors.toUnmodifiableList()));
+        Scheduler.submit(() -> RoseDeleter.deleteDirectory(new File(RoseDB.directory + "/" + database + "/" + collection + "/"), 0));
+    }
+
+    /**
+     * Gets the database, if it exists or else creates a new one.
+     *
+     * @param db The database name to get.
+     * @return the database requested.
+     */
+    public static RoseDatabase getDatabase(String db) {
+        return databases.get(db.toLowerCase());
+    }
+
+    /**
+     * Removes the database and its items.
+     *
+     * @param db The database name to remove.
+     */
+    public static synchronized void removeDatabase(String db) {
+        databases.invalidate(db.toLowerCase());
+        RoseWriter.queue.removeAll(RoseWriter.queue.stream().filter(r -> r.database.equals(db)).collect(Collectors.toUnmodifiableList()));
+        Scheduler.submit(() -> RoseDeleter.deleteDirectory(new File(String.format(RoseDB.directory + "/%s/", db)), 0));
     }
 
 }

--- a/src/main/java/pw/mihou/rosedb/manager/RoseDatabase.java
+++ b/src/main/java/pw/mihou/rosedb/manager/RoseDatabase.java
@@ -9,6 +9,7 @@ import pw.mihou.rosedb.io.FileHandler;
 import java.io.File;
 import java.io.IOException;
 import java.util.Collection;
+import java.util.stream.Collectors;
 
 public class RoseDatabase {
 
@@ -39,6 +40,8 @@ public class RoseDatabase {
 
     public void removeCollection(String collection) throws IOException {
         FileUtils.deleteDirectory(new File(RoseDB.directory + "/" + database + "/" + collection + "/"));
+        FileHandler.queue.removeAll(FileHandler.queue.stream().filter(r -> r.collection.equals(collection))
+                .collect(Collectors.toUnmodifiableList()));
         this.rosy.invalidate(collection);
     }
 

--- a/src/main/java/pw/mihou/rosedb/manager/RoseListenerManager.java
+++ b/src/main/java/pw/mihou/rosedb/manager/RoseListenerManager.java
@@ -2,7 +2,9 @@ package pw.mihou.rosedb.manager;
 
 import io.javalin.websocket.WsContext;
 import org.json.JSONObject;
+import pw.mihou.rosedb.connections.RoseServer;
 import pw.mihou.rosedb.io.Scheduler;
+import pw.mihou.rosedb.io.entities.QueryRequest;
 import pw.mihou.rosedb.manager.entities.RoseListener;
 
 import java.util.ArrayList;
@@ -16,7 +18,22 @@ public class RoseListenerManager {
         listeners.add(listener);
     }
 
+    public static void execute(QueryRequest request, WsContext context) {
+        if(request.database != null && request.database.equalsIgnoreCase(".rose_secrets")){
+            RoseServer.reply(context, "Requested directory is protected by RoseDB.", request.unique, -1);
+            return;
+        }
+
+        listeners.stream().filter(roseListener -> roseListener.type().value.equalsIgnoreCase(request.method))
+                .forEachOrdered(roseListener -> Scheduler.getExecutorService().submit(() -> roseListener.execute(request, context, request.unique)));
+    }
+
     public static void execute(JSONObject request, WsContext context) {
+        if(!request.isNull("database") && request.getString("database").equalsIgnoreCase(".rose_secrets")){
+            RoseServer.reply(context, "Requested directory is protected by RoseDB.", request.getString("unique"), -1);
+            return;
+        }
+
         listeners.stream().filter(roseListener -> roseListener.type().value.equalsIgnoreCase(request.getString("method")))
                 .forEachOrdered(roseListener -> Scheduler.submit(() -> roseListener.execute(request, context, request.getString("unique"))));
     }

--- a/src/main/java/pw/mihou/rosedb/manager/RoseListenerManager.java
+++ b/src/main/java/pw/mihou/rosedb/manager/RoseListenerManager.java
@@ -53,9 +53,7 @@ public class RoseListenerManager {
         }
 
         listeners.stream().filter(roseListener -> roseListener.type().value.equalsIgnoreCase(request.method))
-                .forEachOrdered(roseListener -> Scheduler.getExecutorService().submit(() -> roseListener.execute(request, context,
-                        request.value != null ? (request.valueAsJSONObject().isNull("unique")
-                                ? request.unique : request.valueAsJSONObject().getString("unique")) : request.unique)));
+                .forEachOrdered(roseListener -> Scheduler.getExecutorService().submit(() -> roseListener.execute(request, context, request.unique)));
     }
 
 

--- a/src/main/java/pw/mihou/rosedb/manager/RoseListenerManager.java
+++ b/src/main/java/pw/mihou/rosedb/manager/RoseListenerManager.java
@@ -25,7 +25,8 @@ public class RoseListenerManager {
         }
 
         listeners.stream().filter(roseListener -> roseListener.type().value.equalsIgnoreCase(request.method))
-                .forEachOrdered(roseListener -> Scheduler.getExecutorService().submit(() -> roseListener.execute(request, context, request.unique)));
+                .forEachOrdered(roseListener -> Scheduler.getExecutorService().submit(() -> roseListener.execute(request, context,
+                        request.valueAsJSONObject().isNull("unique") ? request.unique : request.valueAsJSONObject().getString("unique"))));
     }
 
     public static void execute(JSONObject request, WsContext context) {

--- a/src/main/java/pw/mihou/rosedb/manager/RoseListenerManager.java
+++ b/src/main/java/pw/mihou/rosedb/manager/RoseListenerManager.java
@@ -1,24 +1,52 @@
 package pw.mihou.rosedb.manager;
 
-import io.javalin.websocket.WsContext;
+import org.java_websocket.WebSocket;
 import org.json.JSONObject;
 import pw.mihou.rosedb.connections.RoseServer;
+import pw.mihou.rosedb.enums.Levels;
 import pw.mihou.rosedb.io.Scheduler;
 import pw.mihou.rosedb.io.entities.QueryRequest;
+import pw.mihou.rosedb.listeners.*;
 import pw.mihou.rosedb.manager.entities.RoseListener;
+import pw.mihou.rosedb.utility.Terminal;
 
 import java.util.ArrayList;
 import java.util.List;
 
 public class RoseListenerManager {
 
+    /**
+     * The list of listeners that will be listening
+     * to all requests.
+     */
     private static final List<RoseListener> listeners = new ArrayList<>();
 
-    public static void register(RoseListener listener) {
-        listeners.add(listener);
+    /*
+      A method that will register all listeners
+      ahead of time.
+
+      If you are adding a new listener, please add
+      it below the last one.
+     */
+    static {
+        listeners.add(new RequestListener());
+        listeners.add(new AddListener());
+        listeners.add(new DeleteListener());
+        listeners.add(new UpdateListener());
+        listeners.add(new DropListener());
+        listeners.add(new AggregateListener());
+        listeners.add(new RevertListener());
     }
 
-    public static void execute(QueryRequest request, WsContext context) {
+    /**
+     * Checks the value of the field "method" and
+     * looks through the list of listeners to see if any listener
+     * is able to accept the method requested and fires the event for that listener.
+     *
+     * @param request The request sent from the client.
+     * @param context The websocket context of the client.
+     */
+    public static void execute(QueryRequest request, WebSocket context) {
         if(request.database != null && request.database.equalsIgnoreCase(".rose_secrets")){
             RoseServer.reply(context, "Requested directory is protected by RoseDB.", request.unique, -1);
             return;
@@ -26,10 +54,20 @@ public class RoseListenerManager {
 
         listeners.stream().filter(roseListener -> roseListener.type().value.equalsIgnoreCase(request.method))
                 .forEachOrdered(roseListener -> Scheduler.getExecutorService().submit(() -> roseListener.execute(request, context,
-                        request.valueAsJSONObject().isNull("unique") ? request.unique : request.valueAsJSONObject().getString("unique"))));
+                        request.value != null ? (request.valueAsJSONObject().isNull("unique")
+                                ? request.unique : request.valueAsJSONObject().getString("unique")) : request.unique)));
     }
 
-    public static void execute(JSONObject request, WsContext context) {
+
+    /**
+     * Checks the value of the field "method" and
+     * looks through the list of listeners to see if any listener
+     * is able to accept the method requested and fires the event for that listener.
+     *
+     * @param request The request sent from the client.
+     * @param context The websocket context of the client.
+     */
+    public static void execute(JSONObject request, WebSocket context) {
         if(!request.isNull("database") && request.getString("database").equalsIgnoreCase(".rose_secrets")){
             RoseServer.reply(context, "Requested directory is protected by RoseDB.", request.getString("unique"), -1);
             return;

--- a/src/main/java/pw/mihou/rosedb/manager/entities/RoseListener.java
+++ b/src/main/java/pw/mihou/rosedb/manager/entities/RoseListener.java
@@ -1,14 +1,36 @@
 package pw.mihou.rosedb.manager.entities;
 
-import io.javalin.websocket.WsContext;
+import org.java_websocket.WebSocket;
 import org.json.JSONObject;
 import pw.mihou.rosedb.enums.Listening;
 import pw.mihou.rosedb.io.entities.QueryRequest;
 
 public interface RoseListener {
 
+    /**
+     * The type of listener.
+     * This will be used to check whether the listener is able
+     * to take in a certain request.
+     *
+     * @return The listener type.
+     */
     Listening type();
 
-    void execute(QueryRequest request, WsContext context, String unique);
-    void execute(JSONObject request, WsContext context, String unique);
+    /**
+     * Receives an request and handles it appropriately.
+     *
+     * @param request The request that was sent from the client.
+     * @param context The websocket context of the client.
+     * @param unique The unique callback of the client.
+     */
+    void execute(QueryRequest request, WebSocket context, String unique);
+
+    /**
+     * Receives an request and handles it appropriately.
+     *
+     * @param request The request that was sent from the client.
+     * @param context The websocket context of the client.
+     * @param unique The unique callback of the client.
+     */
+    void execute(JSONObject request, WebSocket context, String unique);
 }

--- a/src/main/java/pw/mihou/rosedb/manager/entities/RoseListener.java
+++ b/src/main/java/pw/mihou/rosedb/manager/entities/RoseListener.java
@@ -3,11 +3,12 @@ package pw.mihou.rosedb.manager.entities;
 import io.javalin.websocket.WsContext;
 import org.json.JSONObject;
 import pw.mihou.rosedb.enums.Listening;
+import pw.mihou.rosedb.io.entities.QueryRequest;
 
 public interface RoseListener {
 
     Listening type();
 
+    void execute(QueryRequest request, WsContext context, String unique);
     void execute(JSONObject request, WsContext context, String unique);
-
 }

--- a/src/main/java/pw/mihou/rosedb/server/ServerApplication.java
+++ b/src/main/java/pw/mihou/rosedb/server/ServerApplication.java
@@ -1,0 +1,117 @@
+package pw.mihou.rosedb.server;
+
+import org.apache.commons.codec.digest.HmacAlgorithms;
+import org.apache.commons.codec.digest.HmacUtils;
+import org.java_websocket.WebSocket;
+import org.java_websocket.drafts.Draft;
+import org.java_websocket.drafts.Draft_6455;
+import org.java_websocket.exceptions.InvalidDataException;
+import org.java_websocket.extensions.IExtension;
+import org.java_websocket.handshake.ClientHandshake;
+import org.java_websocket.handshake.ServerHandshakeBuilder;
+import org.java_websocket.protocols.Protocol;
+import org.java_websocket.server.DefaultSSLWebSocketServerFactory;
+import org.java_websocket.server.WebSocketServer;
+import org.json.JSONException;
+import org.json.JSONObject;
+import pw.mihou.rosedb.RoseDB;
+import pw.mihou.rosedb.connections.RoseServer;
+import pw.mihou.rosedb.enums.Levels;
+import pw.mihou.rosedb.io.RoseQuery;
+import pw.mihou.rosedb.io.entities.QueryRequest;
+import pw.mihou.rosedb.manager.RoseListenerManager;
+import pw.mihou.rosedb.utility.Terminal;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.security.MessageDigest;
+import java.util.Collections;
+import java.util.UUID;
+
+public class ServerApplication extends WebSocketServer {
+
+    /**
+     * Creates the server for the application.
+     *
+     * @param port The port to run the server on.
+     */
+    public ServerApplication(int port){
+        super(new InetSocketAddress(port), Collections.singletonList(new Draft_6455(Collections.<IExtension>emptyList(),
+                Collections.singletonList(new Protocol("")),
+                RoseDB.size * 1024 * 1024)));
+
+        if(RoseDB.sslContext != null)
+            setWebSocketFactory(new DefaultSSLWebSocketServerFactory(RoseDB.sslContext));
+    }
+
+    @Override
+    public void stop() throws IOException, InterruptedException {
+        RoseServer.context.values().stream().filter(WebSocket::isOpen)
+                .forEachOrdered(wsContext -> wsContext.close(4002, "RoseDB is closing."));
+        super.stop();
+    }
+
+    @Override
+    public void onOpen(WebSocket conn, ClientHandshake handshake) {
+        Terminal.log(Levels.DEBUG, "Received attempt connection from {}", conn.getRemoteSocketAddress().toString());
+        if(!handshake.hasFieldValue("Authorization")){
+            conn.close(4001, "Missing or invalid Authorization header.");
+            return;
+        }
+
+        if (MessageDigest.isEqual(new HmacUtils(HmacAlgorithms.HMAC_SHA_256, RoseDB.secret)
+                .hmacHex(handshake.getFieldValue("Authorization")).getBytes(), RoseDB.authorization)){
+            conn.setAttachment(UUID.randomUUID().toString().replaceAll("-", ""));
+            RoseServer.context.put(conn.getAttachment(), conn);
+            Terminal.log(Levels.DEBUG, "{} has successfully been connected with ({}) UUID attached.", conn.getRemoteSocketAddress().toString(), conn.getAttachment());
+        } else {
+            conn.close(4001, "Missing or invalid Authorization header.");
+        }
+    }
+
+    @Override
+    public void onClose(WebSocket conn, int code, String reason, boolean remote) {
+        Terminal.log.debug("Received code ({}) close connection from {} with reason {}", code, conn.getAttachment(),
+                reason);
+
+        if(conn.getAttachment() != null && conn.getAttachment() instanceof String)
+            RoseServer.context.remove((String) conn.getAttachment());
+    }
+
+    @Override
+    public void onMessage(WebSocket conn, String message) {
+        if((conn.getAttachment() == null || !(conn.getAttachment() instanceof String)) || (conn.getAttachment() != null && !(conn.getAttachment() instanceof String)
+        && !RoseServer.context.containsKey((String) conn.getAttachment()))){
+            Terminal.log.warn("A client attempted to connect without valid UUID, kicking from connections.");
+            conn.close(4001, "The client is not identified by the server.");
+            return;
+        }
+
+        QueryRequest req = RoseQuery.parse(message);
+        try {
+            if(!req.isValid())
+                RoseListenerManager.execute(new JSONObject(message), conn);
+            else
+                RoseListenerManager.execute(req, conn);
+        } catch (JSONException e) {
+            RoseServer.reply(conn, "The request was considered as invalid: " + e.getMessage(), -1);
+            Terminal.log(Levels.DEBUG, "Received invalid JSON request: {} from {}", message, conn.getRemoteSocketAddress().toString());
+        }
+    }
+
+    @Override
+    public void onError(WebSocket conn, Exception ex) {
+        if(conn != null && conn.isOpen()) {
+            RoseServer.reply(conn, "An exception occurred: " + ex.getMessage(), -1);
+            Terminal.log(Levels.WARNING, "The websocket server returned an exception for remote client {} with reason {}", conn.getAttachment(), ex.getMessage());
+        } else {
+            Terminal.log(Levels.WARNING, "The websocket server returned an exception for a remote client with reason {}", ex.getMessage());
+            ex.printStackTrace();
+        }
+    }
+
+    @Override
+    public void onStart() {
+        Terminal.log(Levels.INFO, "The server is now running at specified port.");
+    }
+}

--- a/src/main/java/pw/mihou/rosedb/utility/Pair.java
+++ b/src/main/java/pw/mihou/rosedb/utility/Pair.java
@@ -18,4 +18,8 @@ public class Pair<T, Y> {
         return right;
     }
 
+    public static <T, Y> Pair<T, Y> of(T left, Y right){
+        return new Pair<>(left, right);
+    }
+
 }

--- a/src/main/java/pw/mihou/rosedb/utility/RoseSSL.java
+++ b/src/main/java/pw/mihou/rosedb/utility/RoseSSL.java
@@ -1,0 +1,109 @@
+package pw.mihou.rosedb.utility;
+
+import jakarta.xml.bind.DatatypeConverter;
+
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManagerFactory;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.security.*;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import java.security.interfaces.RSAPrivateKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.PKCS8EncodedKeySpec;
+
+public class RoseSSL {
+
+    /**
+     * Method which returns a SSLContext from a Let's encrypt or IllegalArgumentException on error
+     *
+     * @return a valid SSLContext
+     * @throws IllegalArgumentException when some exception occurred
+     */
+    public static SSLContext getSSLContextFromLetsEncrypt(String pathTo, String keyPassword) {
+        SSLContext context;
+        try {
+            context = SSLContext.getInstance("TLS");
+
+            byte[] certBytes = parseDERFromPEM(Files.readAllBytes(new File(pathTo + File.separator + "cert.pem").toPath()),
+                    "-----BEGIN CERTIFICATE-----", "-----END CERTIFICATE-----");
+            byte[] keyBytes = parseDERFromPEM(Files.readAllBytes(new File(pathTo + File.separator + "privkey.pem").toPath()),
+                    "-----BEGIN PRIVATE KEY-----", "-----END PRIVATE KEY-----");
+
+            X509Certificate cert = generateCertificateFromDER(certBytes);
+            RSAPrivateKey key = generatePrivateKeyFromDER(keyBytes);
+
+            KeyStore keystore = KeyStore.getInstance("JKS");
+            keystore.load(null);
+            keystore.setCertificateEntry("cert-alias", cert);
+
+            keystore.setKeyEntry("key-alias", key, keyPassword.toCharArray(),
+                    new Certificate[]{CertificateFactory.getInstance("X.509").generateCertificate(new ByteArrayInputStream(certBytes))});
+
+            KeyManagerFactory kmf = KeyManagerFactory.getInstance("SunX509");
+            kmf.init(keystore, keyPassword.toCharArray());
+
+            KeyManager[] km = kmf.getKeyManagers();
+
+            context.init(km, null, null);
+        } catch (IOException | KeyManagementException | KeyStoreException | InvalidKeySpecException
+                | UnrecoverableKeyException | NoSuchAlgorithmException | CertificateException e) {
+            throw new IllegalArgumentException();
+        }
+        return context;
+    }
+
+    /**
+     * Method which returns a SSLContext from a keystore or IllegalArgumentException on error
+     *
+     * @return a valid SSLContext
+     * @throws IllegalArgumentException when some exception occurred
+     */
+    public static SSLContext getSSLConextFromKeystore(String storeType, String keystore, String storePassword, String keyPassword) {
+        KeyStore ks;
+        SSLContext sslContext;
+        try {
+            ks = KeyStore.getInstance(storeType);
+            ks.load(Files.newInputStream(Paths.get("..", keystore)), storePassword.toCharArray());
+            KeyManagerFactory kmf = KeyManagerFactory.getInstance("SunX509");
+            kmf.init(ks, keyPassword.toCharArray());
+            TrustManagerFactory tmf = TrustManagerFactory.getInstance("SunX509");
+            tmf.init(ks);
+
+
+            sslContext = SSLContext.getInstance("TLS");
+            sslContext.init(kmf.getKeyManagers(), tmf.getTrustManagers(), null);
+        } catch (KeyStoreException | IOException | CertificateException | NoSuchAlgorithmException | KeyManagementException | UnrecoverableKeyException e) {
+            throw new IllegalArgumentException();
+        }
+        return sslContext;
+    }
+
+    protected static byte[] parseDERFromPEM(byte[] pem, String beginDelimiter, String endDelimiter) {
+        String data = new String(pem);
+        String[] tokens = data.split(beginDelimiter);
+        tokens = tokens[1].split(endDelimiter);
+        return DatatypeConverter.parseBase64Binary(tokens[0]);
+    }
+
+    protected static RSAPrivateKey generatePrivateKeyFromDER(byte[] keyBytes) throws InvalidKeySpecException, NoSuchAlgorithmException {
+        PKCS8EncodedKeySpec spec = new PKCS8EncodedKeySpec(keyBytes);
+        KeyFactory factory = KeyFactory.getInstance("RSA");
+        return (RSAPrivateKey) factory.generatePrivate(spec);
+    }
+
+    protected static X509Certificate generateCertificateFromDER(byte[] certBytes) throws CertificateException {
+        CertificateFactory factory = CertificateFactory.getInstance("X.509");
+
+        return (X509Certificate) factory.generateCertificate(new ByteArrayInputStream(certBytes));
+    }
+
+}

--- a/src/main/java/pw/mihou/rosedb/utility/UpdateChecker.java
+++ b/src/main/java/pw/mihou/rosedb/utility/UpdateChecker.java
@@ -27,7 +27,7 @@ public class UpdateChecker {
      * The BUILD version of the application.
      * Please change this along with the pom.xml's value.
      */
-    public static final String BUILD = "DEV-SNAPSHOT";
+    public static final String BUILD = "STABLE";
 
     /**
      * The URL-encoded version of the application version.

--- a/src/main/java/pw/mihou/rosedb/utility/UpdateChecker.java
+++ b/src/main/java/pw/mihou/rosedb/utility/UpdateChecker.java
@@ -10,14 +10,36 @@ import java.nio.charset.StandardCharsets;
 
 public class UpdateChecker {
 
-    // Config Version is used to validate for configuration changes.
-    // This will not be checked through the online version and will instead be
-    // done on the application itself.
+    /**
+     * This is used to validate the configuration changes.
+     * This will not be checked through the online version but
+     * will be done at an application level.
+     */
     public static final String CONFIG_VERSION = "1.2";
+
+    /**
+     * The current version of the application.
+     * Please increment this along with pom.xml's version.
+     */
     public static final String VERSION = "1.2.0";
+
+    /**
+     * The BUILD version of the application.
+     * Please change this along with the pom.xml's value.
+     */
     public static final String BUILD = "DEV-SNAPSHOT";
+
+    /**
+     * The URL-encoded version of the application version.
+     * This is the value that will be sent to the API.
+     */
     private static final String ENCODED_VERSION = URLEncoder.encode(VERSION, StandardCharsets.UTF_8);
 
+    /**
+     * Checks whether there is a recent update of RoseDB.
+     *
+     * @return Whether there is a new update of RoseDB.
+     */
     public static boolean check(){
         try {
             HttpURLConnection url = (HttpURLConnection) new URL(new StringBuilder("https://cdn.mihou.pw/rosedb/?update=")

--- a/src/main/java/pw/mihou/rosedb/utility/UpdateChecker.java
+++ b/src/main/java/pw/mihou/rosedb/utility/UpdateChecker.java
@@ -14,7 +14,7 @@ public class UpdateChecker {
     // This will not be checked through the online version and will instead be
     // done on the application itself.
     public static final String CONFIG_VERSION = "1.2";
-    public static final String VERSION = "1.1.0";
+    public static final String VERSION = "1.2.0";
     public static final String BUILD = "DEV-SNAPSHOT";
     private static final String ENCODED_VERSION = URLEncoder.encode(VERSION, StandardCharsets.UTF_8);
 


### PR DESCRIPTION
## What's NEW?
1. RoseDB is now utilizing its own query which is called `Queria`, examples are found on: https://github.com/ShindouMihou/RoseDB/issues/11
2. A little bit stronger authorization (layer 1), more information can be found on: https://github.com/ShindouMihou/RoseDB/issues/10
3. Fixes issue with a condition where items are being revived after having been dropped (because < v1.1.0, dropping collections/database won't actually remove anything that is on queue to be written).
4. Configuration file is now beautified: https://github.com/ShindouMihou/RoseDB/issues/8
5. Fixes some write issues with paths (especially with making directories).
6. Fixes issue with versioning where the versions aren't actually being dumped properly (they are being dumped as folders, yes literal folders).
7. Development snapshot version will no longer update check (since the update check API considers dev-snapshots as old versions).
8. More to be added.

## Important notes
1. Queria will **NOT AND NEVER SUPPORT DATABASES/DIRECTORIES THAT HAS `.` or `,` or `(` or `)` ON THEIR NAMES**.
2. The reason for the change above is because we are using databases and collections with `.` as a protected RoseDB directory, for example, storing the hash token.
3. We will be dropping support for JSON requests on v1.3.0.

## How does Queria look like?
A Queria request that has a `unique` field (which is used for callbacks) will look like this: 

```json
database.collection.get(identifier, {"unique":"Unique value"})
```

A Queria request that does not need a `unique` field will look like this: 
```json
database.collection.get(identifier)
```

A Queria multiple field update/delete request will look like this: 
```json
database.collection.update(identifier, {"key":["key1","key2"],"value":["value1","value2"]})
```

A Queria add request will look like this: 
```json
database.collection.update(identifier, {"someKey":"someValue"})
```

## Notes about Queria
Queria is still experimental and will undergo several changes along the way but the basic concept is the same, all the value will always be in `JSON` since RoseDB will still store data as `JSON` files.

## What to expect next?
1. File-locking (to prevent external changes, deletions or additions to the database folders that RoseDB will not recognize).
2. Websocket SSL (Yes, I am still looking into this).
3. **POSSIBLE** Adding support for instant write to disk.

## How to install the development snapshot version?
Please note that you will be installing a possibly bug-filled version of RoseDB, but Iwon't discourage you from installing this new version as I also want other testers to help find issues with the application.

To install, simply replace your `RoseDB.jar` file with the development snapshot jar on: https://github.com/ShindouMihou/RoseDB/releases/tag/v1.2.0-DEV